### PR TITLE
Fix inverted docstring/comments on GET / index route

### DIFF
--- a/breba_app/main.py
+++ b/breba_app/main.py
@@ -94,8 +94,8 @@ async def sitemap():
 async def index(request: Request):
     """
     Home page route.
-    If cookie "X-Chainlit-Session-id" is set, render home.html
-    otherwise render app.html
+    If cookie "X-Chainlit-Session-id" is set, render app.html (builder UI).
+    Otherwise render home.html (landing page).
     """
     session_cookie = request.cookies.get("X-Chainlit-Session-id")
     oauth_success = request.cookies.get("oauth_success")
@@ -106,10 +106,8 @@ async def index(request: Request):
         return response
 
     if session_cookie:
-        # Cookie missing → render app.html
         return templates.TemplateResponse("app.html", {"request": request})
     else:
-        # Cookie exists → render home.html
         return templates.TemplateResponse("home.html", {"request": request})
 
 

--- a/breba_app/main.py
+++ b/breba_app/main.py
@@ -94,8 +94,13 @@ async def sitemap():
 async def index(request: Request):
     """
     Home page route.
-    If cookie "X-Chainlit-Session-id" is set, render app.html (builder UI).
-    Otherwise render home.html (landing page).
+
+    If "oauth_success" cookie is set (post-OAuth callback), render home.html
+    with login_success=True and clear the cookie. This takes precedence over
+    session_cookie.
+
+    Otherwise: "X-Chainlit-Session-id" cookie present → app.html (builder UI);
+    absent → home.html (landing page).
     """
     session_cookie = request.cookies.get("X-Chainlit-Session-id")
     oauth_success = request.cookies.get("oauth_success")


### PR DESCRIPTION
## Summary

The docstring and two inline comments on `index()` (`breba_app/main.py:93-113`) have described the **opposite** of what the code actually does since the route was introduced in `38e0ef0` (Aug 2025). The `3fa0796` `base.html` → `app.html` rename preserved the inversion verbatim. This PR makes the wording match the code.

**No behavior change.** The runtime logic is untouched.

## What was wrong

| Source | Said | Truth |
|---|---|---|
| Docstring (lines 97-98) | cookie set → `home.html`, otherwise → `app.html` | inverted |
| Comment line 109 (`# Cookie missing → render app.html`) | branch taken when cookie missing | branch is taken when cookie is **present** |
| Comment line 112 (`# Cookie exists → render home.html`) | branch taken when cookie exists | branch is taken when cookie is **absent** |
| Actual code | cookie present → `app.html`; cookie absent → `home.html` | correct (and matches semantic intent) |

## Why the code is the truth (not the docstring)

1. **`app.html` is the builder UI.** Title `Breba Builder`, generator iframe, upload modal, action bar, version dropdown. A sessioned user (Chainlit cookie set) belongs there.
2. **`base.html` (when this route was first written) was a 35-line Jinja shell with `{% block content %}{% endblock %}` and nothing else.** Rendering it standalone produced an empty page — so the original docstring's "cookie set → render home.html, otherwise → render base.html" would mean *anonymous* visitors get a blank page. Nobody would design that.
3. **The `oauth_success` short-circuit corroborates intent.** Fresh OAuth login → `home.html` with `login_success=True` (a "welcome back" landing flow). That branch only makes sense if the *normal* `if session_cookie:` branch routes sessioned users *somewhere other than* `home.html` — i.e., the builder.
4. **Reading the comments at face value gives broken UX.** "Cookie exists → render home.html" means logged-in users always see the landing page with no in-app way to reach the builder.

## Why nobody noticed

The `if session_cookie:` branch barely fires in real traffic — Chainlit sets `X-Chainlit-Session-id` on the WS upgrade, not on the initial `GET /`. Most users hit `/` first (no cookie → `home.html`), the WS connects later, the cookie is set after they're already navigating elsewhere. So whichever template `if session_cookie:` returned was rarely seen, and the docstring/comments were never reality-checked.

## Diff

3-line net change in `breba_app/main.py`:
- Flip the two docstring lines to match the code.
- Delete the two inverted inline comments (they were pure restatement of the code anyway).

## Test plan

- [ ] Read the updated `index()` — confirm docstring describes what the code does
- [ ] Smoke test: `GET /` with no cookies → `home.html` body
- [ ] Smoke test: `GET /` with `X-Chainlit-Session-id` cookie set → `app.html` body
- [ ] Smoke test: `GET /` with `oauth_success` cookie set → `home.html` with `login_success=True` (unchanged)