### PR TITLE
Fix stale docstring and current-page prompt typos

### DIFF
--- a/breba_app/orchestrator.py
+++ b/breba_app/orchestrator.py
@@ -148,7 +148,7 @@ async def baml_stream_and_collect_user_response(stream: BamlStream, stream_recei
 
 def _current_page_messages(page: str) -> list[LLMMessage]:
     return [LLMMessage(role="user", content=f"The user is currently viewing: {page}\n"),
-            LLMMessage(role="assistant", content="I understand the the user is making comments while view this page, but the comments may be about any part of the product, not just the current page.")]
+            LLMMessage(role="assistant", content="I understand the user is making comments while viewing this page, but the comments may be about any part of the product, not just the current page.")]
 
 
 @agent_task

--- a/breba_app/storage.py
+++ b/breba_app/storage.py
@@ -246,7 +246,7 @@ def _user_session_object(user_id: str, session_id: str, relative_path: str, desc
 def save_image_to_private(user_id: str, session_id: str, image_name: str, content: bytes, description: str = None):
     """
     Save image bytes to private bucket. This is used for uploads of images form AI, but is not safe for user-uploaded images.
-    :param user_id: username
+    :param user_id: user identifier used to namespace the user's files
     :param session_id: session id used for locating image files
     :param image_name: image name
     :param content: image content


### PR DESCRIPTION
Two stale-text fixes surfaced while reviewing the `user_name`→`user_id` rename:

- `storage.py`: `save_image_to_private` docstring described `user_id` as *"username"* (stale after the rename); now describes it as the user-namespace identifier.
- `orchestrator.py`: `_current_page_messages` assistant message had `the the` and `while view this page`; corrected to `the user … while viewing this page`.

No behavior change.