### PR TITLE
Tidy github_controller deploy + modernize json-logger import

### DIFF
--- a/breba_app/github_controller.py
+++ b/breba_app/github_controller.py
@@ -123,7 +123,7 @@ async def deploy_to_github(user_id: str, product_id: str, filestore: FileStore, 
     token = decrypt_token(user.github_access_token)
 
     try:
-        files = {path: fw.content for path, fw in filestore._files.items()}
+        files = {path: filestore.read_bytes(path) for path in filestore.list_files()}
 
         if product.github_repo:
             # Re-deploy: push updated files to existing repo
@@ -137,7 +137,7 @@ async def deploy_to_github(user_id: str, product_id: str, filestore: FileStore, 
                 return GitHubDeployResult(success=False, error="An organization name is required for the first deploy.")
             repo_name = slugify(product.name or "breba-page")
             repo_info = await create_repo(token, org, repo_name)
-            repo_name = repo_info["name"]  # may have been suffixed for uniqueness
+            repo_name = repo_info["name"]  # canonical name from GitHub (create_repo find-or-creates; matches the requested slug)
             deploy_org = org
             # Push files before enabling Pages — Pages API requires content on the branch
             await push_files(token, deploy_org, repo_name, files)

--- a/breba_app/logging_config.py
+++ b/breba_app/logging_config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger.json import JsonFormatter
 
 from breba_app.context import get_context
 
@@ -32,7 +32,7 @@ def setup_logging(level: int | str = logging.INFO, fmt: str | None = None) -> No
     handler.addFilter(ContextFilter())
 
     if fmt == "json":
-        handler.setFormatter(jsonlogger.JsonFormatter(_JSON_FIELDS))
+        handler.setFormatter(JsonFormatter(_JSON_FIELDS))
     else:
         handler.setFormatter(logging.Formatter(_TEXT_FORMAT))
 


### PR DESCRIPTION
Small code-hygiene cleanups (behaviorally equivalent):

- **`github_controller.deploy_to_github`**: build the `files` dict via the public `FileStore` API (`read_bytes`/`list_files`) instead of reaching into the private `_files` attribute. `read_bytes` returns the same bytes and `list_files` returns the already-normalized keys, so the output is identical — and it's now type-safe against the `FileStore` protocol (the previous code only worked for `InMemoryFileStore`).
- **`github_controller`**: correct the stale `# may have been suffixed for uniqueness` comment — `create_repo` find-or-creates and never suffixes, so the returned name matches the requested slug.
- **`logging_config`**: use the modern `from pythonjsonlogger.json import JsonFormatter` import; the legacy `pythonjsonlogger.jsonlogger` path is deprecated since python-json-logger 3.1 (pin `>=3.2.0`, lock 4.1.0). Only the `LOG_FORMAT=json` branch is affected.