### PR TITLE
Add an MCP server and headless API so local coding agents can edit a site

### DIFF
--- a/STANDALONE_SETUP.md
+++ b/STANDALONE_SETUP.md
@@ -1,0 +1,508 @@
+# Standalone Local Setup
+
+Run disc-site locally at **http://localhost:8080** without cloud accounts. This setup replaces
+the production services with local ones:
+
+| Production | Local replacement |
+|---|---|
+| Cloudflare R2 | MinIO (Docker) |
+| MongoDB Atlas | MongoDB (Docker) |
+| `*.breba.site` preview CDN | Caddy reverse proxy (optional, for the in-app preview pane) |
+| Google SSO | Password login (`scripts/create_user.bash`) |
+| OpenAI (site generation) | Optional — see [What works without API keys](#what-works-without-api-keys) |
+
+All local config goes in **`.secrets/breba/`** at the repo root. The `.env` inside it is
+git-ignored; the other files are not, so exclude the directory locally to keep `git status` clean:
+`echo '.secrets/' >> .git/info/exclude`. Run every command in this guide from the repo root.
+
+> **The commands below are written for macOS** and install things with Homebrew. Nothing here is
+> macOS-specific in principle — Linux and Windows/WSL should work with the equivalent packages —
+> but only macOS has been tested. Substitute your own package manager where `brew` appears.
+
+Ports used: **8080** app · **9000/9001** MinIO S3/console · **27017** MongoDB · **8088**
+preview proxy.
+
+The guide is split into the order you need:
+
+1. **[Setup](#1-setup-first-run)** — create config, install dependencies, start infra, create a
+   user, and seed a starter product.
+2. **[Day-to-day: run & stop](#2-day-to-day-run--stop)** — the commands you will use after setup.
+3. **[Teardown](#3-teardown-full-wipe)** — remove local data and config.
+
+
+## Prerequisites
+
+1. **[`uv`](https://docs.astral.sh/uv/)** — the only hard requirement. You do not need to install
+   Python yourself: uv fetches the version pinned in `.python-version` (3.13).
+
+   ```bash
+   brew install uv
+   # or, without Homebrew:
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. **Dependencies** — run once from the repo root. This downloads Python 3.13 if it is missing
+   and creates `.venv`:
+
+   ```bash
+   uv sync
+   ```
+
+3. **A Docker-compatible runtime** — Docker Desktop, or
+   [Colima](https://github.com/abiosoft/colima) if you want a free local runtime:
+
+   ```bash
+   brew install colima docker docker-compose
+   colima start --cpu 4 --memory 4
+   docker compose version        # confirm the v2 compose plugin works
+   ```
+
+4. **Caddy**, only if you want the in-app preview pane:
+
+   ```bash
+   brew install caddy
+   ```
+
+## 1. Setup (first run)
+
+This section is one-time setup. When you finish, the app will be running at
+http://localhost:8080 with a local user and a starter product.
+
+### 1.1 Create the config files
+
+Create the config directory:
+
+```bash
+mkdir -p .secrets/breba
+```
+
+Create the files below.
+
+<details>
+<summary><b><code>.secrets/breba/infra.compose.yml</code></b> — MinIO + MongoDB</summary>
+
+The app runs on your host with `./start.bash`, so `localhost:9000` and `localhost:27017` reach
+the container ports. The one-shot `createbuckets` service waits for MinIO, creates both buckets,
+and makes the public bucket readable so previews open in a browser.
+
+```bash
+cat > .secrets/breba/infra.compose.yml <<'EOF'
+name: breba-local
+
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"   # S3 API   -> CLOUDFLARE_ENDPOINT
+      - "9001:9001"   # web console (http://localhost:9001, minioadmin/minioadmin)
+    volumes:
+      - minio-data:/data
+
+  # One-shot: waits for MinIO, creates the two buckets, makes the public one
+  # world-readable so generated previews can be opened in a browser.
+  createbuckets:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 minioadmin minioadmin; do echo 'waiting for minio...'; sleep 2; done;
+      mc mb -p local/dev-breba-users;
+      mc mb -p local/dev-breba-public;
+      mc anonymous set download local/dev-breba-public;
+      echo 'buckets ready'; exit 0;
+      "
+
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  minio-data:
+  mongo-data:
+EOF
+```
+
+</details>
+
+<details>
+<summary><b><code>.secrets/breba/Caddyfile</code></b> — preview proxy (optional)</summary>
+
+Create this only if you want the in-app preview pane or local product URLs like
+`http://<product_id>.localhost:8088/`.
+
+In production, each product has its own origin (`https://<product_id>.breba.site/`). That lets
+asset paths like `/styles.css` resolve correctly. Caddy recreates that behavior on top of MinIO.
+Browsers already resolve `*.localhost` to `127.0.0.1`, so you do not need `/etc/hosts`, DNS, or
+TLS.
+
+```bash
+cat > .secrets/breba/Caddyfile <<'EOF'
+# <product_id>.localhost:8088/<path> -> MinIO dev-breba-public/<product_id>/<path>
+http://*.localhost:8088 {
+	# Previews change on every push/edit; sub-resources (styles.css, js) must
+	# never be served from the browser cache without revalidation.
+	header Cache-Control no-store
+
+	# Root request serves index.html (MinIO has no directory index).
+	@root path /
+	handle @root {
+		rewrite * /dev-breba-public/{labels.1}/index.html
+		reverse_proxy localhost:9000 {
+			header_up Host localhost:9000
+		}
+	}
+
+	# Everything else: map the first host label (the product_id) to the bucket prefix.
+	handle {
+		rewrite * /dev-breba-public/{labels.1}{uri}
+		reverse_proxy localhost:9000 {
+			header_up Host localhost:9000
+		}
+	}
+}
+EOF
+```
+
+</details>
+
+<details>
+<summary><b><code>.secrets/breba/.env</code></b> — app environment</summary>
+
+The app finds this file automatically. The commands below generate the Chainlit auth secret and
+Fernet key, then write the full env file. Replace `OPENAI_API_KEY` later if you want chat-driven
+site generation.
+
+```bash
+SECRET=$(uv run chainlit create-secret 2>/dev/null | grep CHAINLIT_AUTH_SECRET | cut -d= -f2- | tr -d '"')
+FERNET=$(uv run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+
+cat > .secrets/breba/.env <<EOF
+# --- LLM (a real key is only needed for chat-driven generation; see the guide) ---
+OPENAI_API_KEY=sk-local-dev-unused
+TAVILY_API_KEY=
+
+# --- MongoDB (local) ---
+MONGO_URI=mongodb://localhost:27017
+
+# --- S3 / MinIO (in place of Cloudflare R2) ---
+CLOUDFLARE_ENDPOINT=http://localhost:9000
+USERS_BUCKET=dev-breba-users
+PUBLIC_BUCKET=dev-breba-public
+CDN_BASE_URL=http://localhost:9000/dev-breba-public
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_PROFILE=breba-local
+# boto3 sends request checksums some S3-compatibles reject; relax them:
+AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
+
+# --- Auth / crypto ---
+# Single-quoted: the secret may contain \$, which docker compose would
+# otherwise interpolate (with "variable is not set" warnings) when it loads
+# this .env for the infra stack. python-dotenv strips the quotes on read.
+CHAINLIT_AUTH_SECRET='$SECRET'
+TOKEN_ENCRYPTION_KEY=$FERNET
+
+# --- Unused locally (kept present so the env loader is satisfied) ---
+GITHUB_PERSONAL_ACCESS_TOKEN=
+CHAINLIT_ROOT_PATH=
+CHAINLIT_URL=http://localhost:8080
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+# Chainlit's import-time guard requires >=1 fully-configured OAuth provider, so
+# these two must be NON-EMPTY dummies. Local login uses password auth.
+OAUTH_GOOGLE_CLIENT_ID=local-dev-disabled
+OAUTH_GOOGLE_CLIENT_SECRET=local-dev-disabled
+EOF
+```
+
+</details>
+
+<details>
+<summary><b><code>~/.aws/config</code></b> — path-style S3 addressing for MinIO (appends a profile)</summary>
+
+boto3 defaults to virtual-host S3 addressing (`bucket.localhost`), which local MinIO cannot serve
+by DNS. This adds a dedicated profile that forces path-style addressing. The `.env` above selects
+it with `AWS_PROFILE=breba-local`; credentials still come from env vars.
+
+```bash
+mkdir -p ~/.aws
+cat >> ~/.aws/config <<'EOF'
+
+[profile breba-local]
+s3 =
+    addressing_style = path
+EOF
+```
+
+</details>
+
+### 1.2 Optional: in-app preview-pane patch
+
+The app's preview pane uses the production `*.breba.site` URL by default, so it 404s locally.
+Apply this patch only if you want previews inside the app. Without it, everything else still
+works, and you can open products directly at `http://<product_id>.localhost:8088/` when Caddy is
+running.
+
+<details>
+<summary><b>Patch <code>breba_app/storage.py</code></b> and hide the edit from git</summary>
+
+Replace `get_index_html_path()` in `breba_app/storage.py` with:
+
+```python
+def get_index_html_path(product_id: str) -> str:
+    cdn = Settings.CDN_BASE_URL
+    if cdn and ("localhost" in cdn or "127.0.0.1" in cdn):
+        return f"http://{product_id}.localhost:8088/index.html"
+    return f"{get_public_url(product_id)}/index.html"
+```
+
+Then hide this local-only edit from git:
+
+```bash
+git update-index --skip-worktree breba_app/storage.py    # undo: --no-skip-worktree
+```
+
+> **Important:** undo `skip-worktree` before committing or pulling. It hides incoming changes to
+> `storage.py`. This is the only tracked file this guide touches.
+
+</details>
+
+### 1.3 Start the infra
+
+```bash
+docker compose -f .secrets/breba/infra.compose.yml up -d
+```
+
+Verify the containers. `minio` and `mongo` should be `Up`, and `createbuckets` should have exited
+with code 0:
+
+```bash
+docker compose -f .secrets/breba/infra.compose.yml ps
+```
+
+### 1.4 Create a login user
+
+Create a password user. This replaces Google SSO locally:
+
+```bash
+./scripts/create_user.bash
+```
+
+### 1.5 Seed a starter product
+
+Seeding creates a starter product without an LLM call. It writes a minimal site to local storage
+and prints the `user_id` and `product_id`.
+
+<details>
+<summary><b><code>.secrets/breba/seed_product.py</code></b> — the seeding helper</summary>
+
+This helper creates the same durable state the coder agent normally leaves behind: a Mongo
+`Product` document, versioned files in the users bucket, and preview files in the public bucket.
+The site content comes from an existing integration-test fixture, so no generation is needed.
+
+```bash
+cat > .secrets/breba/seed_product.py <<'EOF'
+"""
+Seed a starter product for an existing user, without any LLM call.
+
+Writes a pre-built minimal site straight to storage, replicating the durable
+state the coder agent leaves behind: a Mongo Product doc, versioned files in
+the users bucket, and preview files in the public bucket. Prints the user_id
+and product_id.
+
+Usage (from the repo root):
+    PYTHONPATH=. uv run python .secrets/breba/seed_product.py <username>
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+from breba_app.config import init_db, load_env
+from breba_app.filesystem.in_memory_store import InMemoryFileStore
+from breba_app.models.product import create_blank_product_for
+from breba_app.models.user import User
+from breba_app.storage import save_files
+from breba_app.website import build_preview
+
+load_env()
+
+# A complete minimal site matching the shape of real coder output (an existing
+# integration-test fixture); reused so a product can be created with zero LLM calls.
+SEED_CONTENT_DIR = Path("tests/integration/coder_agent_test_cases/hello_world_create/expected")
+SEED_PRODUCT_NAME = "Starter Site"
+
+
+async def seed_starter_product(user_id: str):
+    file_store = InMemoryFileStore()
+    for path in sorted(SEED_CONTENT_DIR.iterdir()):
+        if path.is_file():
+            file_store.write_text(path.name, path.read_text())
+
+    product = await create_blank_product_for(user_id, SEED_PRODUCT_NAME, active=True)
+    version = await save_files(user_id, product.product_id, list(file_store.snapshot().values()))
+    await build_preview(product.product_id, file_store)
+    return product, version
+
+
+async def run(username: str):
+    await init_db()
+
+    user = await User.find_one(User.username == username)
+    if not user:
+        print(f"User not found: {username}")
+        sys.exit(1)
+
+    product, version = await seed_starter_product(str(user.id))
+    print(f"Seeded product {product.product_id!r} (version {version})")
+    print(f"user_id:    {user.id}")
+    print(f"product_id: {product.product_id}")
+
+
+if len(sys.argv) != 2:
+    print("Usage: PYTHONPATH=. uv run python .secrets/breba/seed_product.py <username>")
+    sys.exit(1)
+
+asyncio.run(run(sys.argv[1]))
+EOF
+```
+
+</details>
+
+Run it with the username from step 1.4. Save the printed `product_id`:
+
+```bash
+PYTHONPATH=. uv run python .secrets/breba/seed_product.py <username>
+```
+
+Alternative: use chat generation instead of seeding. This requires a real `OPENAI_API_KEY` in
+`.secrets/breba/.env`. Start the app, then describe a simple site in the chat UI, such as
+*"a one-page site for a coffee shop"*.
+
+### 1.6 Start the app and verify
+
+```bash
+caddy start --config .secrets/breba/Caddyfile    # optional: preview pane
+./start.bash                                     # app on :8080
+```
+
+Then verify the setup:
+
+- Sign in at **http://localhost:8080/** with your password user. The starter product should be
+  listed.
+- With Caddy: open `http://<product_id>.localhost:8088/`. The seeded site should render.
+- Storage (optional): MinIO console at http://localhost:9001 (minioadmin/minioadmin) —
+  versioned files under `dev-breba-users/<user_id>/<product_id>/`, preview files under
+  `dev-breba-public/<product_id>/`.
+
+Setup is done. After this, use the run and stop commands below.
+
+## 2. Day-to-day: run & stop
+
+Users, products, and site files persist in Docker volumes, so you do not need to re-run setup.
+
+**Run:**
+
+```bash
+colima start                                             # skip if using Docker Desktop
+docker compose -f .secrets/breba/infra.compose.yml up -d
+caddy start --config .secrets/breba/Caddyfile            # optional: preview pane
+./start.bash                                             # app on :8080
+```
+
+Sign in at **http://localhost:8080/** with your password user.
+
+<details>
+<summary><b>Health check</b></summary>
+
+```bash
+docker compose -f .secrets/breba/infra.compose.yml ps    # minio + mongo Up
+curl -s -o /dev/null -w '%{http_code}\n' localhost:8080  # 200
+```
+
+</details>
+
+**Stop:**
+
+```bash
+# Ctrl-C in the ./start.bash terminal
+caddy stop                                               # if started
+docker compose -f .secrets/breba/infra.compose.yml down  # WITHOUT -v: -v wipes your data
+colima stop                                              # skip if using Docker Desktop
+```
+
+## 3. Teardown (full wipe)
+
+> **Stop the app first:** press `Ctrl-C` in the terminal running `./start.bash`.
+
+Then stop Caddy:
+
+```bash
+caddy stop                                               # if started
+```
+
+Delete all local data and config:
+
+```bash
+docker compose -f .secrets/breba/infra.compose.yml down -v   # deletes users, products, site files
+rm -rf .secrets/breba                                        # env, compose file, Caddyfile, seed script
+```
+
+If you applied the preview-pane patch in step 1.2, undo it:
+
+```bash
+git update-index --no-skip-worktree breba_app/storage.py
+git checkout -- breba_app/storage.py
+```
+
+Also remove these by hand if you created them:
+
+- the `[profile breba-local]` block in `~/.aws/config`
+- the `.secrets/` line in `.git/info/exclude`
+
+```bash
+colima stop      # or `colima delete` to remove the VM entirely; skip if using Docker Desktop
+```
+
+## What works without API keys
+
+The app can boot with a dummy `OPENAI_API_KEY`; the value only needs to be non-empty. Login,
+seeded products, preview, and version history all work without a real `OPENAI_API_KEY` — none of
+them calls the LLM. The key is needed for chat-driven generation and edits, automatic product
+naming, and `AGENTS.md` summaries.
+
+## Troubleshooting
+
+- **S3 `SignatureDoesNotMatch` / bucket-not-found / connection errors** → MinIO may be down, the
+  endpoint may be wrong, or path-style addressing may not be applied. Check
+  `AWS_PROFILE=breba-local` in `.env` and the `[profile breba-local]` block in `~/.aws/config`.
+- **Upload/checksum errors against MinIO** → make sure the two `AWS_*CHECKSUM*` vars are set.
+- **`ValueError: You must set the environment variable for at least one oauth provider`** →
+  `OAUTH_GOOGLE_CLIENT_ID/SECRET` must both be non-empty dummies.
+- **`RuntimeError: <VAR> is not set`** on boot → a required key is missing or empty in
+  `.secrets/breba/.env`.
+- **`.secrets directory not found`** → run from the repo root; `.secrets/breba/.env` must exist.
+- **Login fails** → re-run `./scripts/create_user.bash`; confirm Mongo is up.
+- **Product won't generate via chat** → `OPENAI_API_KEY` must be real. Check the `start.bash`
+  logs for the OpenAI error. Only chat needs the key; seeding does not.
+- **Preview pane blank / CSS 403** → Caddy may not be running, or the step 1.2 patch may not be
+  applied. Verify
+  `curl -s -o /dev/null -w '%{http_code}\n' http://<product_id>.localhost:8088/styles.css` → 200,
+  then restart `./start.bash`.
+- **Preview empty for an existing product** → public files missing under
+  `dev-breba-public/<product_id>/`; trigger a rebuild by clicking a version in the app's version
+  menu (LLM-free) or sending a chat message.
+- **Push succeeds but preview doesn't update** → the Caddy proxy isn't running.
+- **`colima start` fails: "vz driver is running but host agent is not"** → stale
+  `~/.colima/_lima/colima/vz.pid` after an unclean shutdown. Confirm nothing lima/vz is running
+  (`ps aux | grep -i lima`), then delete the pid file and retry. Your data is unaffected.
+- **`docker compose` not found (Colima)** → symlink the compose plugin into
+  `~/.docker/cli-plugins/` (the `docker-compose` brew formula prints the command).

--- a/STANDALONE_SETUP.md
+++ b/STANDALONE_SETUP.md
@@ -27,7 +27,9 @@ The guide is split into the order you need:
 1. **[Setup](#1-setup-first-run)** — create config, install dependencies, start infra, create a
    user, and seed a starter product.
 2. **[Day-to-day: run & stop](#2-day-to-day-run--stop)** — the commands you will use after setup.
-3. **[Teardown](#3-teardown-full-wipe)** — remove local data and config.
+3. **[Connect a coding agent (MCP)](#3-connect-a-coding-agent-mcp)** — let coding agents edit a
+   local product.
+4. **[Teardown](#4-teardown-full-wipe)** — remove local data and config.
 
 
 ## Prerequisites
@@ -211,6 +213,9 @@ AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
 CHAINLIT_AUTH_SECRET='$SECRET'
 TOKEN_ENCRYPTION_KEY=$FERNET
 
+# --- MCP push API tuning (optional; defaults shown, uncomment to change) ---
+# MCP_MAX_FILE_BYTES=20971520          # per-file /mcp/push cap in bytes (20 MB), 413 above it
+
 # --- Unused locally (kept present so the env loader is satisfied) ---
 GITHUB_PERSONAL_ACCESS_TOKEN=
 CHAINLIT_ROOT_PATH=
@@ -300,7 +305,7 @@ Create a password user. This replaces Google SSO locally:
 ### 1.5 Seed a starter product
 
 Seeding creates a starter product without an LLM call. It writes a minimal site to local storage
-and prints the `user_id` and `product_id`.
+and prints the `user_id` and `product_id` you will need later for MCP.
 
 <details>
 <summary><b><code>.secrets/breba/seed_product.py</code></b> — the seeding helper</summary>
@@ -317,7 +322,7 @@ Seed a starter product for an existing user, without any LLM call.
 Writes a pre-built minimal site straight to storage, replicating the durable
 state the coder agent leaves behind: a Mongo Product doc, versioned files in
 the users bucket, and preview files in the public bucket. Prints the user_id
-and product_id.
+and product_id (needed for MCP tokens/pushes).
 
 Usage (from the repo root):
     PYTHONPATH=. uv run python .secrets/breba/seed_product.py <username>
@@ -439,7 +444,21 @@ docker compose -f .secrets/breba/infra.compose.yml down  # WITHOUT -v: -v wipes 
 colima stop                                              # skip if using Docker Desktop
 ```
 
-## 3. Teardown (full wipe)
+## 3. Connect a coding agent (MCP)
+
+Driving a local product from your own coding agent — Claude Code, Codex, Cursor, OpenCode, or a
+local model — is the main reason to run this stack. The MCP server in `mcp_server/` exposes the
+site as a set of tools: the agent reads and writes files, and every push creates a new revision
+and rebuilds the preview. Deploying stays a Breba UI action.
+
+Both MCP transports work: **stdio**, where the agent launches the server itself, and **Streamable
+HTTP**, where you run one long-lived server that agents connect to by URL.
+
+Quick start, per-agent config examples, first-run authorization, and a detailed overview are
+all in
+**[`mcp_server/README.md`](mcp_server/README.md)**.
+
+## 4. Teardown (full wipe)
 
 > **Stop the app first:** press `Ctrl-C` in the terminal running `./start.bash`.
 
@@ -454,6 +473,7 @@ Delete all local data and config:
 ```bash
 docker compose -f .secrets/breba/infra.compose.yml down -v   # deletes users, products, site files
 rm -rf .secrets/breba                                        # env, compose file, Caddyfile, seed script
+rm -rf ~/.config/breba-mcp                                   # cached MCP token, if you used MCP
 ```
 
 If you applied the preview-pane patch in step 1.2, undo it:
@@ -467,6 +487,11 @@ Also remove these by hand if you created them:
 
 - the `[profile breba-local]` block in `~/.aws/config`
 - the `.secrets/` line in `.git/info/exclude`
+- agent MCP configs: `<workspace>/.mcp.json`, `<workspace>/opencode.json`,
+  `<workspace>/.cursor/mcp.json`, `<workspace>/.codex/config.toml`,
+  `<workspace>/hermes-breba.sh` + `<workspace>/.hermes/`, and the `breba-site` entries in
+  `~/.gemini/config/mcp_config.json` (agy) / `~/.hermes/config.yaml` (Hermes) /
+  `~/.codex/config.toml` (Codex)
 
 ```bash
 colima stop      # or `colima delete` to remove the VM entirely; skip if using Docker Desktop
@@ -475,9 +500,9 @@ colima stop      # or `colima delete` to remove the VM entirely; skip if using D
 ## What works without API keys
 
 The app can boot with a dummy `OPENAI_API_KEY`; the value only needs to be non-empty. Login,
-seeded products, preview, and version history all work without a real `OPENAI_API_KEY` — none of
-them calls the LLM. The key is needed for chat-driven generation and edits, automatic product
-naming, and `AGENTS.md` summaries.
+seeded products, preview, version history, and MCP push/read all work without a real
+`OPENAI_API_KEY` — none of them calls the LLM. The key is needed for chat-driven generation and
+edits, automatic product naming, and `AGENTS.md` summaries.
 
 ## Troubleshooting
 
@@ -492,7 +517,7 @@ naming, and `AGENTS.md` summaries.
 - **`.secrets directory not found`** → run from the repo root; `.secrets/breba/.env` must exist.
 - **Login fails** → re-run `./scripts/create_user.bash`; confirm Mongo is up.
 - **Product won't generate via chat** → `OPENAI_API_KEY` must be real. Check the `start.bash`
-  logs for the OpenAI error. Only chat needs the key; seeding does not.
+  logs for the OpenAI error. Only chat needs the key; seeding and MCP push do not.
 - **Preview pane blank / CSS 403** → Caddy may not be running, or the step 1.2 patch may not be
   applied. Verify
   `curl -s -o /dev/null -w '%{http_code}\n' http://<product_id>.localhost:8088/styles.css` → 200,
@@ -501,6 +526,8 @@ naming, and `AGENTS.md` summaries.
   `dev-breba-public/<product_id>/`; trigger a rebuild by clicking a version in the app's version
   menu (LLM-free) or sending a chat message.
 - **Push succeeds but preview doesn't update** → the Caddy proxy isn't running.
+- **MCP consent page shows no products / "Product not found"** → the signed-in user does not own
+  the target `product_id`, or no product exists yet. Go back to step 1.5.
 - **`colima start` fails: "vz driver is running but host agent is not"** → stale
   `~/.colima/_lima/colima/vz.pid` after an unclean shutdown. Confirm nothing lima/vz is running
   (`ps aux | grep -i lima`), then delete the pid file and retry. Your data is unaffected.

--- a/breba_app/main.py
+++ b/breba_app/main.py
@@ -26,6 +26,8 @@ from breba_app.context import bind_context
 from breba_app.logging_config import setup_logging
 from breba_app.github_controller import enforce_github_https, get_github_connection_status, handle_github_callback, \
     list_github_orgs, set_github_custom_domain
+from breba_app.mcp_api.authorize import router as mcp_authorize_router
+from breba_app.mcp_api.router import router as mcp_router
 from breba_app.models.product import Product
 from breba_app.models.user import User
 from breba_app.orchestrator import load_state, state_exists
@@ -363,6 +365,9 @@ async def upload_files(
 
     return JSONResponse({"version": new_version})
 
+
+app.include_router(mcp_router)
+app.include_router(mcp_authorize_router)
 
 current_file_dir = Path(__file__).parent
 mount_chainlit(app=app, target=str(current_file_dir / "my_cl_app.py"), path="/chainlit")

--- a/breba_app/mcp_api/auth.py
+++ b/breba_app/mcp_api/auth.py
@@ -1,0 +1,166 @@
+"""Stateless HMAC tokens for the headless MCP push API.
+
+Generalizes the proven signing pattern in ``github_oauth.generate_state`` /
+``verify_state`` from a bare username to an arbitrary dict payload. No new server
+secret and no DB state: tokens are signed with the existing ``CHAINLIT_AUTH_SECRET``
+and carry their own expiry.
+
+Two payload kinds share one scheme:
+- ``tok``  — the long-lived bearer token the agent sends on every request.
+- ``code`` — a short-lived code used by the browser auth flow so the bearer
+             token never lands in a redirect URL / browser history. Codes are
+             single-use, enforced per-process via ``consume_code``: the tokens
+             themselves are stateless, so a multi-worker deployment would need
+             shared storage for the consumed-nonce registry (the app currently
+             runs single-process — the same assumption the live-session overlay
+             makes).
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import threading
+import time
+
+from fastapi import HTTPException, Request
+
+DEFAULT_TOKEN_TTL = 30 * 24 * 3600  # 30 days
+DEFAULT_CODE_TTL = 60               # seconds
+
+
+def _secret() -> str:
+    s = os.environ.get("CHAINLIT_AUTH_SECRET", "")
+    if not s:
+        raise RuntimeError("CHAINLIT_AUTH_SECRET not set")
+    return s
+
+
+def _sign(payload: dict) -> str:
+    """Return ``base64url(json(payload)).hmac_sha256`` (same shape as github_oauth)."""
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    sig = hmac.new(_secret().encode(), body.encode(), hashlib.sha256).hexdigest()
+    return f"{body}.{sig}"
+
+
+def _verify(token: str) -> dict | None:
+    """Return the payload if signature is valid and unexpired, else None.
+
+    A missing ``CHAINLIT_AUTH_SECRET`` is server misconfiguration, not a bad
+    token — the secret is resolved outside the ``except`` so the RuntimeError
+    propagates (surfacing as a 500) instead of masquerading as a 401.
+    """
+    secret = _secret()
+    try:
+        body, sig = token.split(".", 1)
+        expected = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(sig, expected):
+            return None
+        data = json.loads(base64.urlsafe_b64decode(body).decode())
+        if data.get("exp", 0) < time.time():
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def _mint(kind: str, user_id: str, product_id: str, ttl: int,
+          extra: dict | None = None) -> tuple[str, dict]:
+    payload = {"t": kind, "user_id": user_id, "product_id": product_id,
+               "exp": time.time() + ttl, **(extra or {})}
+    return _sign(payload), payload
+
+
+def mint_token(user_id: str, product_id: str,
+               ttl: int = DEFAULT_TOKEN_TTL) -> tuple[str, dict]:
+    """Bearer token plus its payload, so callers that need the authoritative
+    ``exp`` never re-verify a token they just signed themselves."""
+    return _mint("tok", user_id, product_id, ttl)
+
+
+def verify_token(token: str) -> dict | None:
+    data = _verify(token)
+    return data if data and data.get("t") == "tok" else None
+
+
+def mint_code(user_id: str, product_id: str, ttl: int = DEFAULT_CODE_TTL,
+              code_challenge: str = "") -> str:
+    """Mint a browser code; a non-empty ``code_challenge`` (PKCE S256) rides in
+    the signed payload, so the binding needs no server-side state.
+
+    Only codes carry a ``nonce``: it exists for ``consume_code``'s single-use
+    accounting, which bearer tokens deliberately don't have."""
+    extra = {"nonce": secrets.token_hex(8)}
+    if code_challenge:
+        extra["code_challenge"] = code_challenge
+    return _mint("code", user_id, product_id, ttl, extra)[0]
+
+
+def verify_code(code: str) -> dict | None:
+    """Pure signature/expiry check — no single-use accounting (see consume_code)."""
+    data = _verify(code)
+    return data if data and data.get("t") == "code" else None
+
+
+def make_code_challenge(verifier: str) -> str:
+    """PKCE S256 transform (RFC 7636): unpadded base64url of sha256(verifier)."""
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def code_challenge_matches(verifier: str, challenge: str) -> bool:
+    return hmac.compare_digest(make_code_challenge(verifier), challenge)
+
+
+# Single-use enforcement for browser codes. Per-process only: a multi-worker
+# deployment would need shared storage. Entries live at most DEFAULT_CODE_TTL
+# past minting, so the registry stays tiny; expired entries are pruned on access.
+_consumed_nonces: dict[str, float] = {}  # nonce -> exp
+_consumed_lock = threading.Lock()
+
+
+def reset_consumed_codes() -> None:
+    """Clear the consumed-nonce registry (test isolation hook)."""
+    with _consumed_lock:
+        _consumed_nonces.clear()
+
+
+def consume_code(code: str) -> dict | None:
+    """Verify a browser code AND mark it consumed; None if invalid or already used.
+
+    The check-and-record happens under a lock so two concurrent exchanges of the
+    same leaked code cannot both succeed.
+    """
+    data = verify_code(code)
+    if not data:
+        return None
+    nonce = data.get("nonce", "")
+    now = time.time()
+    with _consumed_lock:
+        for n in [n for n, exp in _consumed_nonces.items() if exp < now]:
+            del _consumed_nonces[n]
+        if nonce in _consumed_nonces:
+            return None
+        _consumed_nonces[nonce] = data["exp"]
+    return data
+
+
+def require_push_token(request: Request) -> dict:
+    """FastAPI dependency: authenticate via ``Authorization: Bearer <token>``.
+
+    Replaces both the Chainlit cookie auth and the in-memory ``state_exists``
+    session requirement that the browser ``/upload`` path depends on. On any
+    failure, 401 with a ``WWW-Authenticate`` pointer so the MCP client knows to
+    start the browser flow at ``/mcp/authorize``.
+    """
+    header = request.headers.get("Authorization", "")
+    token = header[7:] if header.lower().startswith("bearer ") else ""
+    data = verify_token(token)
+    if not data:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid token; authorize at /mcp/authorize",
+            headers={"WWW-Authenticate": 'Bearer realm="/mcp/authorize"'},
+        )
+    return data  # {"user_id", "product_id", ...}

--- a/breba_app/mcp_api/authorize.py
+++ b/breba_app/mcp_api/authorize.py
@@ -34,11 +34,9 @@ because the page keeps the one-time authorize URL alive (sign-in opens in a
 new tab; a continue link re-hits the same URL once the session cookie exists),
 the latter because the URI can't be trusted.
 
-CSRF posture of the consent POST (deliberate): it relies on the Chainlit
-session cookie's SameSite behavior plus the loopback-only ``redirect_uri``
-restriction — an attacker who tricked a signed-in user into submitting the
-form would additionally need a listener on the victim's own machine to receive
-the code.
+CSRF: the consent POST requires a same-origin ``Origin``/``Referer`` header
+(``_same_origin``), so protection does not depend on the session cookie's
+SameSite setting; the loopback-only ``redirect_uri`` remains a second layer.
 """
 from urllib.parse import urlencode, urlparse
 
@@ -83,6 +81,12 @@ def _is_loopback(redirect_uri: str) -> bool:
     except ValueError:
         return False
     return parsed.scheme in ("http", "https") and parsed.hostname in _LOOPBACK_HOSTS
+
+
+def _same_origin(request: Request) -> bool:
+    """CSRF check independent of the cookie's SameSite setting; fails closed."""
+    src = request.headers.get("origin") or request.headers.get("referer")
+    return bool(src) and urlparse(src).netloc == request.url.netloc
 
 
 def _redirect_back(redirect_uri: str, **params: str) -> str:
@@ -202,6 +206,9 @@ async def authorize_decision(request: Request, redirect_uri: str = Form(""),
     if not _is_loopback(redirect_uri):
         return _message(request, "Invalid request",
                         "redirect_uri must be a loopback address.", status_code=400)
+    if not _same_origin(request):
+        return _redirect_error(redirect_uri, "invalid_origin",
+                               "Consent must be submitted from the Breba consent page.", state)
     if current_user is None:
         return _redirect_error(redirect_uri, "session_expired",
                                "Your Breba session expired. Sign in in the browser and retry.",

--- a/breba_app/mcp_api/authorize.py
+++ b/breba_app/mcp_api/authorize.py
@@ -1,0 +1,253 @@
+"""SSO-gated browser authorization for the headless MCP push API.
+
+Implements the interactive loopback flow (RFC 8252 "native app" pattern, like
+``gh auth login``). It reuses the product's *existing* Chainlit / Google SSO
+login — no new login system, no ``User`` schema change:
+
+  1. The local MCP server opens ``GET /mcp/authorize?redirect_uri=&state=
+     &product_id=&code_challenge=`` in the user's browser. ``code_challenge`` is
+     the PKCE S256 hash (RFC 7636) of a verifier the MCP server keeps locally.
+  2. The user signs in with the normal SSO/password (the Chainlit session cookie)
+     and is shown a consent page: "Allow this agent to push to <product> as <you>?".
+  3. On approve we mint a short-lived (60s) ``code`` and redirect to the loopback
+     ``redirect_uri?code=&state=``. ``redirect_uri`` is restricted to loopback
+     hosts so the code can't be exfiltrated to an arbitrary server. The code is
+     single-use — enforced per-process by ``auth.consume_code`` (see ``auth.py``
+     for the multi-worker caveat) — and carries the ``code_challenge`` inside its
+     signed payload, so the PKCE binding needs no server-side state.
+  4. The MCP server exchanges the code (plus the PKCE ``code_verifier``) at
+     ``POST /mcp/token`` for the real, long-lived bearer token. Doing the swap
+     server-side keeps the bearer token out of browser history / redirect logs;
+     PKCE means a code intercepted in transit or from a log still can't be
+     exchanged without the verifier, which never leaves the MCP server.
+
+The token itself is the same stateless HMAC token from ``auth.py``, signed with
+``CHAINLIT_AUTH_SECRET`` — the agent receives a *token*, never the server secret.
+
+Terminal errors (wrong product ID, expired session, denied consent, …) are
+redirected back to the loopback ``redirect_uri`` as ``error=`` /
+``error_description=`` query params, OAuth-style, once ``redirect_uri`` has
+passed the loopback check. Rendering an error page instead would strand the
+local MCP server waiting for a callback that never comes. Only "sign in
+required" (GET) and an invalid ``redirect_uri`` still render pages: the former
+because the page keeps the one-time authorize URL alive (sign-in opens in a
+new tab; a continue link re-hits the same URL once the session cookie exists),
+the latter because the URI can't be trusted.
+
+CSRF posture of the consent POST (deliberate): it relies on the Chainlit
+session cookie's SameSite behavior plus the loopback-only ``redirect_uri``
+restriction — an attacker who tricked a signed-in user into submitting the
+form would additionally need a listener on the victim's own machine to receive
+the code.
+"""
+from urllib.parse import urlencode, urlparse
+
+from chainlit.auth import authenticate_user, reuseable_oauth
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import BaseModel
+
+from breba_app.mcp_api.auth import (
+    code_challenge_matches,
+    consume_code,
+    mint_code,
+    mint_token,
+)
+from breba_app.mcp_api.products import owned_products, product_listing
+from breba_app.models.user import User
+from breba_app.paths import templates
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+async def optional_current_user(session_token: str | None = Depends(reuseable_oauth)):
+    """Resolve the logged-in Chainlit user, or ``None`` if not signed in.
+
+    Unlike ``chainlit.auth.get_current_user``, this never raises on a missing or
+    invalid session — the browser flow renders a friendly "sign in first" page
+    instead of a bare 401.
+    """
+    if not session_token:
+        return None
+    try:
+        return await authenticate_user(session_token)
+    except HTTPException:
+        return None
+
+
+def _is_loopback(redirect_uri: str) -> bool:
+    try:
+        parsed = urlparse(redirect_uri)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and parsed.hostname in _LOOPBACK_HOSTS
+
+
+def _redirect_back(redirect_uri: str, **params: str) -> str:
+    sep = "&" if urlparse(redirect_uri).query else "?"
+    return f"{redirect_uri}{sep}{urlencode(params)}"
+
+
+def _redirect_error(redirect_uri: str, error: str, description: str, state: str) -> RedirectResponse:
+    """Send a terminal error back to the loopback callback (OAuth-style).
+
+    Rendering an error page instead would leave the local MCP server waiting
+    forever for a callback that never comes — the agent's tool call would hang.
+    Only call this with an already-validated loopback ``redirect_uri``.
+    """
+    return RedirectResponse(
+        _redirect_back(redirect_uri, error=error, error_description=description, state=state),
+        status_code=303,
+    )
+
+
+def _message(request: Request, heading: str, message: str, status_code: int = 200,
+             link_url: str | None = None, link_text: str | None = None,
+             link_new_tab: bool = False, continue_url: str | None = None,
+             continue_text: str | None = None) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request,
+        "mcp_message.html",
+        {"heading": heading, "message": message,
+         "link_url": link_url, "link_text": link_text, "link_new_tab": link_new_tab,
+         "continue_url": continue_url, "continue_text": continue_text},
+        status_code=status_code,
+    )
+
+
+async def _resolve_owner(current_user, redirect_uri: str, state: str):
+    """Map the signed-in Chainlit identity to its DB user and their products.
+
+    Returns ``(db_user, products, None)`` on success, ``(None, None, error_redirect)``
+    when the account can't be located — both handlers report that the same
+    OAuth-style way. The products list is what the consent page renders and what
+    the approval validates the requested product against, so both handlers load
+    it here rather than issuing a separate per-product lookup.
+    """
+    db_user = await User.find_one(User.username == current_user.identifier)
+    if not db_user:
+        return None, None, _redirect_error(redirect_uri, "account_not_found",
+                                           "Your account could not be located.", state)
+    return db_user, await owned_products(db_user.id), None
+
+
+def _invalid_product_error(redirect_uri: str, product_id: str, state: str) -> RedirectResponse:
+    return _redirect_error(
+        redirect_uri, "invalid_product",
+        f"Product '{product_id}' does not exist or is not yours. "
+        "Check BREBA_PRODUCT_ID and retry.", state,
+    )
+
+
+@router.get("/authorize", response_class=HTMLResponse)
+async def authorize(request: Request, redirect_uri: str = "", state: str = "",
+                    product_id: str = "", code_challenge: str = "",
+                    current_user=Depends(optional_current_user)):
+    if current_user is None:
+        # This URL's query (redirect_uri, state, code_challenge, product_id) is
+        # the one-time authorize request the waiting MCP server minted, and the
+        # login flow has no "next"-style return redirect — after SSO the user
+        # lands on "/". So sign-in opens in a new tab and this page keeps the
+        # authorize URL alive itself: the continue link re-hits the same URL,
+        # now with the session cookie present, and lands on the consent page.
+        original_url = request.url.path + (
+            f"?{request.url.query}" if request.url.query else "")
+        return _message(
+            request, "Sign in required",
+            "Sign in to Breba in the new tab, then come back here and continue "
+            "to authorize the agent.",
+            status_code=401, link_url="/login", link_text="Sign in",
+            link_new_tab=True,
+            continue_url=original_url, continue_text="I've signed in — continue",
+        )
+    if not _is_loopback(redirect_uri):
+        return _message(
+            request, "Invalid request",
+            "redirect_uri must be a loopback address (127.0.0.1 or localhost).",
+            status_code=400,
+        )
+
+    _, products, error = await _resolve_owner(current_user, redirect_uri, state)
+    if error:
+        return error
+    if not products:
+        return _redirect_error(
+            redirect_uri, "no_products",
+            "You have no products yet. Create one in the Breba app, then retry.", state,
+        )
+    if product_id and not any(p.product_id == product_id for p in products):
+        return _invalid_product_error(redirect_uri, product_id, state)
+
+    return templates.TemplateResponse(
+        request,
+        "mcp_consent.html",
+        {
+            "username": current_user.identifier,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": code_challenge,
+            "selected_product_id": product_id,
+            "products": product_listing(products),
+        },
+    )
+
+
+@router.post("/authorize")
+async def authorize_decision(request: Request, redirect_uri: str = Form(""),
+                             state: str = Form(""), product_id: str = Form(""),
+                             decision: str = Form(""), code_challenge: str = Form(""),
+                             current_user=Depends(optional_current_user)):
+    if not _is_loopback(redirect_uri):
+        return _message(request, "Invalid request",
+                        "redirect_uri must be a loopback address.", status_code=400)
+    if current_user is None:
+        return _redirect_error(redirect_uri, "session_expired",
+                               "Your Breba session expired. Sign in in the browser and retry.",
+                               state)
+
+    if decision != "approve":
+        return RedirectResponse(
+            _redirect_back(redirect_uri, error="access_denied", state=state),
+            status_code=303,
+        )
+
+    db_user, products, error = await _resolve_owner(current_user, redirect_uri, state)
+    if error:
+        return error
+    if not any(p.product_id == product_id for p in products):
+        return _invalid_product_error(redirect_uri, product_id, state)
+
+    code = mint_code(str(db_user.id), product_id, code_challenge=code_challenge)
+    return RedirectResponse(
+        _redirect_back(redirect_uri, code=code, state=state),
+        status_code=303,
+    )
+
+
+class TokenIn(BaseModel):
+    code: str
+    code_verifier: str = ""
+
+
+@router.post("/token")
+async def token(body: TokenIn):
+    """Exchange a single-use browser code for a long-lived bearer token.
+
+    ``consume_code`` (not ``verify_code``) so a leaked code can't be exchanged
+    twice — the second attempt gets the same 400 as an invalid code. When the
+    code carries a PKCE challenge, the exchange must present the matching
+    verifier; the code is consumed before the PKCE check, so a failed attempt
+    burns it. Codes minted without a challenge (older or third-party clients)
+    are still accepted — PKCE here is client-initiated defense in depth on top
+    of the loopback-only redirect and single-use codes, not a mandate.
+    """
+    data = consume_code(body.code)
+    if not data:
+        raise HTTPException(400, detail="Invalid, expired, or already used code")
+    challenge = data.get("code_challenge", "")
+    if challenge and not code_challenge_matches(body.code_verifier, challenge):
+        raise HTTPException(400, detail="code_verifier does not match the code's challenge")
+    bearer, payload = mint_token(data["user_id"], data["product_id"])
+    return {"token": bearer, "product_id": data["product_id"], "expires_at": payload["exp"]}

--- a/breba_app/mcp_api/preview.py
+++ b/breba_app/mcp_api/preview.py
@@ -1,0 +1,94 @@
+"""Incremental preview publishing for the MCP push path.
+
+``website.build_preview`` uploads every built file to the public preview bucket
+on every call. The Jinja ``build`` step must still see the full filestore —
+cross-file includes mean one pushed partial can change other pages' rendered
+output — but MCP pushes are merge-only, so most built files come out
+byte-identical to what the bucket already holds. This module mirrors
+``build_preview``'s behavior while skipping those uploads: one LIST of the
+product's preview prefix yields the existing ETags (the body MD5 for
+single-part ``put_object`` uploads), and only files whose built bytes differ
+are re-uploaded. Anything that defeats the comparison (multipart ETags,
+encryption) just fails the match and re-uploads — correctness never depends on
+the skip.
+"""
+import asyncio
+import hashlib
+import logging
+
+from breba_app.builder import build
+from breba_app.filesystem import FileStore
+from breba_app.storage import PreviewFileStore, Settings, get_s3_client
+# _inject_preview_bridge is private to website.py, but it is the single
+# definition of what the preview bridge is; duplicating the injection here
+# would let the MCP and browser preview paths drift.
+from breba_app.website import _inject_preview_bridge
+
+logger = logging.getLogger(__name__)
+
+
+def _list_preview_etags(product_id: str, bucket=None) -> dict[str, str]:
+    """ETags of the product's existing preview objects, in the target bucket.
+
+    ``bucket`` is the same boto3 Bucket resource ``PreviewFileStore`` takes, so
+    the skip decisions are made against the bucket the writes actually go to;
+    ``None`` means the default public preview bucket.
+    """
+    bucket_name = bucket.name if bucket is not None else Settings.PUBLIC_BUCKET
+    etags: dict[str, str] = {}
+    paginator = get_s3_client().get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket_name, Prefix=f"{product_id}/"):
+        for obj in page.get("Contents", []):
+            etags[obj["Key"]] = obj["ETag"].strip('"')
+    return etags
+
+
+def _render(filestore: FileStore) -> tuple[dict[str, bytes], dict[str, str], list[str]]:
+    """Jinja-render the site into preview bytes plus their MD5s.
+
+    Pure CPU and in-memory work (render, bridge-injection regexes, hashing) —
+    the caller runs it in a thread so concurrent Chainlit websockets and
+    ``/mcp`` requests aren't stalled for the whole pass.
+    Returns ``(rendered bytes by path, md5 hex by path, failed paths)``.
+    """
+    built = build(filestore)
+    rendered: dict[str, bytes] = {}
+    md5s: dict[str, str] = {}
+    failed: list[str] = []
+    for path in built.list_files():
+        try:
+            lower = path.lower()
+            if lower.endswith(".html") or lower.endswith(".htm"):
+                content = _inject_preview_bridge(built.read_text(path)).encode("utf-8")
+            else:
+                content = built.read_bytes(path)
+        except Exception:
+            logger.exception("Failed to copy %r to preview; skipping", path)
+            failed.append(path)
+            continue
+        rendered[path] = content
+        md5s[path] = hashlib.md5(content).hexdigest()
+    return rendered, md5s, failed
+
+
+async def build_preview_incremental(product_id: str, filestore: FileStore, bucket=None) -> None:
+    """Behavioral clone of ``website.build_preview`` that skips unchanged uploads."""
+    # The ETag LIST and the render are independent, and both are blocking
+    # (S3 I/O vs. CPU-bound Jinja/regex/MD5) — run them concurrently off the loop.
+    existing, (rendered, md5s, failed) = await asyncio.gather(
+        asyncio.to_thread(_list_preview_etags, product_id, bucket),
+        asyncio.to_thread(_render, filestore),
+    )
+
+    target = PreviewFileStore(product_id=product_id, bucket=bucket)
+    for path, content in rendered.items():
+        # _make_key is private to PreviewFileStore, but it is the single
+        # definition of where a preview file lands — the same key the LIST saw.
+        if existing.get(target._make_key(path)) == md5s[path]:
+            continue  # byte-identical to what the bucket already holds
+        target.write_bytes(path, content)
+
+    await target.flush()
+
+    if failed:
+        raise RuntimeError(f"Preview build failed for {len(failed)} file(s): {', '.join(failed)}")

--- a/breba_app/mcp_api/products.py
+++ b/breba_app/mcp_api/products.py
@@ -1,0 +1,18 @@
+"""Owned-product listing shared by the consent page and ``/mcp/products``.
+
+``/mcp/products`` promises the same list the user already sees on the consent
+page; keeping the query and the {"id", "name"} projection here makes that
+contract structural instead of two copies kept in sync by hand.
+"""
+from beanie import PydanticObjectId
+
+from breba_app.models.product import Product
+
+
+async def owned_products(user_oid: PydanticObjectId) -> list[Product]:
+    return await Product.find(Product.user.id == user_oid).to_list()
+
+
+def product_listing(products: list[Product]) -> list[dict]:
+    """{"id", "name"} entries; a product with no name falls back to its id."""
+    return [{"id": p.product_id, "name": p.name or p.product_id} for p in products]

--- a/breba_app/mcp_api/router.py
+++ b/breba_app/mcp_api/router.py
@@ -1,0 +1,235 @@
+"""Headless, token-authenticated MCP push API.
+
+Mirrors the effect of the browser ``POST /upload`` path in ``main.py`` but is
+session-free: instead of an in-memory orchestrator session (``state_exists``) it
+sources the product's current state from durable storage (R2/MinIO) on every call,
+overlays the pushed files, and persists a new version + rebuilt preview.
+
+Contract: push *merges* the given files onto current state and never
+deletes unpushed files. Only the pushed files are written; ``batch_write`` clones
+the latest version's manifest, so unpushed files are carried forward by the
+manifest merge, not by re-uploading the whole snapshot. This matches the
+platform-wide append/overwrite-only invariant (no single-file delete exists
+anywhere). There is deliberately **no deploy endpoint**: going live stays a
+site-UI-only action.
+
+The live-session overlay relies on per-process in-memory orchestrator state
+(``state_exists``/``load_state``), so it assumes a single-process deployment —
+the same limitation as the browser ``/upload`` path.
+"""
+import asyncio
+import base64
+import binascii
+import logging
+import os
+
+from beanie import PydanticObjectId
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from breba_app.filesystem.models import FileWrite
+# _sanitize_path is private to versioned_r2, but it is the single source of truth
+# for path rules; duplicating it here would let router and storage validation drift.
+from breba_app.filesystem.versioned_r2 import NotFound, _sanitize_path
+from breba_app.mcp_api import store
+from breba_app.mcp_api.auth import require_push_token
+from breba_app.mcp_api.preview import build_preview_incremental
+from breba_app.mcp_api.products import owned_products, product_listing
+from breba_app.models.product import Product
+from breba_app.orchestrator import load_state, state_exists
+from breba_app.storage import (
+    get_active_version,
+    get_index_html_path,
+    list_versions,
+    save_files,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+
+class FileIn(BaseModel):
+    path: str
+    content_b64: str
+    # Advisory MIME type recorded in the version manifest. When omitted the
+    # storage layer guesses from the extension, which stamps extensionless
+    # text files (CNAME, LICENSE) as application/octet-stream — the MCP read
+    # tools would then refuse to read them back as text.
+    content_type: str | None = None
+
+
+class PushIn(BaseModel):
+    files: list[FileIn]
+    # A best-effort optimistic-concurrency precondition supplied by the local
+    # MCP server after it reads the active site. This deliberately guards
+    # stale-agent edits without changing the product-wide storage write path.
+    expected_version: int | None = None
+
+
+@router.post("/push")
+async def push(body: PushIn, principal: dict = Depends(require_push_token)):
+    user_id, product_id = principal["user_id"], principal["product_id"]
+    # Push targets a pre-existing product only; it never bootstraps one.
+    if not await Product.find_one(Product.product_id == product_id):
+        raise HTTPException(404, detail="Product not found; create it in the site UI first.")
+
+    if not body.files:
+        raise HTTPException(400, detail="No files to push")
+
+    # Validate every path and decode every payload before any side effect, so one
+    # bad file rejects the whole batch before anything is written anywhere. The
+    # cap is read here (not at import) so tests can adjust MCP_MAX_FILE_BYTES; the
+    # `or` treats a blank value (`VAR=` line in a .env) as unset, not int("").
+    cap = int(os.environ.get("MCP_MAX_FILE_BYTES") or 20 * 1024 * 1024)
+    decoded: list[FileWrite] = []
+    for f in body.files:
+        try:
+            path = _sanitize_path(f.path)
+        except ValueError as exc:
+            raise HTTPException(400, detail=f"Invalid file path: {f.path}") from exc
+        try:
+            content = base64.b64decode(f.content_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise HTTPException(400, detail=f"Invalid base64 content for {f.path}") from exc
+        if len(content) > cap:
+            raise HTTPException(
+                413, detail=f"{f.path} is {len(content)} bytes; the per-file cap is {cap} bytes",
+            )
+        decoded.append(FileWrite(path=path, content=content, content_type=f.content_type))
+
+    # Reject edits prepared from an older snapshot rather than silently
+    # overwriting a change the browser/chat agent made in the meantime. This is
+    # intentionally a preflight, not a cross-process transaction: the product
+    # currently treats simultaneous writers as out of scope. Unguarded pushes
+    # skip the lookup entirely — no round-trip for a value that goes unused.
+    active_version = None
+    if body.expected_version is not None:
+        active_version = await get_active_version(user_id, product_id)
+        if body.expected_version != active_version:
+            raise HTTPException(
+                409,
+                detail=(
+                    f"Site changed from revision {body.expected_version} to {active_version} "
+                    "since it was read. Re-read the affected files and reapply the edit before pushing."
+                ),
+            )
+
+    # Durable current state; a guarded push passes the version its preflight
+    # just resolved instead of re-reading the pointer.
+    full_store = await store.read_all_files(user_id, product_id, active_version)
+    for fw in decoded:
+        full_store.write_bytes(fw.path, fw.content)
+
+    # Persist only the pushed files: the manifest merge in batch_write carries
+    # unpushed files forward, and re-saving the whole snapshot would widen the
+    # window where a concurrent chat edit gets clobbered by a stale re-write.
+    # Save must complete *before* the preview build starts — unlike POST /upload,
+    # which runs the two concurrently: if the save failed, an already-running
+    # build would publish files to the public bucket with no version recorded.
+    version = await save_files(user_id, product_id, decoded)
+
+    # A live chat session holds its own InMemoryFileStore (orchestrator._state_store),
+    # loaded at chat start; without this overlay the next coder run would edit stale
+    # files and persist them, silently reverting this push (POST /upload does the
+    # same, before its preview build). Overlay as soon as the save is durable —
+    # a preview failure below must not leave the open session poised to revert
+    # an already-persisted push.
+    if state_exists(user_id, product_id):
+        live_store = load_state(user_id, product_id).filestore
+        for fw in decoded:
+            live_store.write_bytes(fw.path, fw.content)
+
+    try:
+        await build_preview_incremental(product_id, full_store)
+    except Exception as e:
+        # The push itself persisted; report the preview failure distinctly so
+        # the client doesn't re-push the same files (stacking identical
+        # versions) thinking the save failed.
+        logger.exception("Preview build failed after push (version %s)", version)
+        raise HTTPException(
+            500,
+            detail=(
+                f"Files were saved as version {version}, but rebuilding the "
+                f"preview failed: {e}. Do not re-push the same files; fix the "
+                "reported problem and push the fix to refresh the preview."
+            ),
+        ) from e
+
+    return {"version": version, "product_id": product_id}
+
+
+@router.get("/versions")
+async def versions(principal: dict = Depends(require_push_token)):
+    user_id, product_id = principal["user_id"], principal["product_id"]
+    all_versions, active = await asyncio.gather(
+        list_versions(user_id, product_id),
+        get_active_version(user_id, product_id),
+    )
+    return {"versions": all_versions, "active": active}
+
+
+@router.get("/files")
+async def files(version: int | None = None, principal: dict = Depends(require_push_token)):
+    try:
+        paths, resolved_version = await store.list_files(
+            principal["user_id"], principal["product_id"], version,
+        )
+    except NotFound as e:
+        # The message names the resolved version, so a defaulted read that hits
+        # a missing manifest is reported precisely, never as "Version None".
+        raise HTTPException(404, detail=str(e)) from e
+    return {"files": paths, "version": resolved_version}
+
+
+@router.get("/file")
+async def file(path: str, version: int | None = None, principal: dict = Depends(require_push_token)):
+    try:
+        fw, resolved_version = await store.read_file(
+            principal["user_id"], principal["product_id"], path, version,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, detail=f"Invalid file path: {path}") from exc
+    except NotFound as e:
+        # read_file's message names the missing piece: the version or the path.
+        raise HTTPException(404, detail=str(e)) from e
+    content = fw.content.encode("utf-8") if isinstance(fw.content, str) else fw.content
+    return {
+        "path": path,
+        "content_b64": base64.b64encode(content).decode(),
+        "version": resolved_version,
+    }
+
+
+@router.get("/file/stat")
+async def file_stat(path: str, version: int | None = None,
+                    principal: dict = Depends(require_push_token)):
+    """Manifest metadata for one file, so clients can refuse binary or
+    oversized content before paying for the download."""
+    try:
+        meta = await store.stat_file(principal["user_id"], principal["product_id"], path, version)
+    except ValueError as exc:
+        raise HTTPException(400, detail=f"Invalid file path: {path}") from exc
+    except NotFound as e:
+        raise HTTPException(404, detail=str(e)) from e
+    return {"path": path, **meta}
+
+
+@router.get("/preview")
+async def preview(principal: dict = Depends(require_push_token)):
+    return {"preview_url": get_index_html_path(principal["product_id"])}
+
+
+@router.get("/products")
+async def products(principal: dict = Depends(require_push_token)):
+    """List every product the token's user owns; ``current`` is the token's product.
+
+    Any of the user's product-scoped tokens may call this — the list is user-level
+    data the same user already sees on the consent page. It lets an MCP agent map
+    a product *name* the user mentioned to the id ``switch_product`` needs.
+    """
+    owned = await owned_products(PydanticObjectId(principal["user_id"]))
+    return {
+        "products": product_listing(owned),
+        "current": principal["product_id"],
+    }

--- a/breba_app/mcp_api/store.py
+++ b/breba_app/mcp_api/store.py
@@ -1,0 +1,133 @@
+"""Targeted version-aware reads for the MCP API.
+
+``storage.read_all_files_in_memory`` downloads every file's bytes, which is far
+more than ``/mcp/files`` (manifest metadata only) or ``/mcp/file`` (one object)
+need. These helpers construct ``VersionedR2FileSystem`` directly — same pattern
+as ``breba_app.storage`` — and touch only the objects actually requested.
+"""
+import asyncio
+
+from botocore.exceptions import ClientError
+
+from breba_app.filesystem import InMemoryFileStore
+from breba_app.filesystem.models import FileWrite
+from breba_app.filesystem.versioned_r2 import NotFound, VersionedR2FileSystem, _sanitize_path
+from breba_app.storage import Settings, get_s3_client
+
+
+def _filesystem(user_id: str, product_id: str) -> VersionedR2FileSystem:
+    return VersionedR2FileSystem(
+        bucket_name=Settings.USERS_BUCKET,
+        root_prefix=f"{user_id}/{product_id}",
+        s3_client=get_s3_client(),
+    )
+
+
+async def list_files(user_id: str, product_id: str,
+                     version: int | None = None) -> tuple[list[str], int]:
+    """List paths in the given version (the active one when None).
+
+    Returns ``(paths, resolved_version)``: ``None`` is resolved here, once, so
+    the version reported back is exactly the one whose manifest was listed —
+    callers echoing it never re-resolve and risk disagreeing with the read.
+    """
+    filesystem = _filesystem(user_id, product_id)
+
+    # VersionedR2FileSystem.list_files is synchronous S3 I/O; keep it off the event loop.
+    def _sync() -> tuple[list[str], int]:
+        v = filesystem.get_version() if version is None else version
+        return filesystem.list_files(v), v
+
+    return await asyncio.to_thread(_sync)
+
+
+async def read_file(user_id: str, product_id: str, path: str,
+                    version: int | None = None) -> tuple[FileWrite, int]:
+    """Read one file from the given version (the active one when None).
+
+    Returns ``(file, resolved_version)`` — same single-resolution contract as
+    ``list_files``.
+    """
+    filesystem = _filesystem(user_id, product_id)
+    v = version if version is not None else await asyncio.to_thread(filesystem.get_version)
+    return await filesystem.read_file(path, version=v), v
+
+
+async def stat_file(user_id: str, product_id: str, path: str,
+                    version: int | None = None) -> dict:
+    """Manifest metadata ({"size", "content_type"}) for one file — no download.
+
+    Lets clients refuse binary or oversized files *before* fetching the bytes.
+    Version 0 resolves like ``read_file``'s version-0 branch — a HEAD of the
+    unversioned object — because legacy pre-versioning products keep their
+    real files outside the placeholder v0 manifest. All of this metadata is
+    advisory (v0 objects and pushes may carry guessed or missing types), so
+    callers must keep their post-download backstops.
+    """
+    sanitized = _sanitize_path(path)  # validate before touching storage config
+    filesystem = _filesystem(user_id, product_id)
+
+    def _sync() -> dict:
+        v = filesystem.get_version() if version is None else version
+        if v == 0:
+            # Mirror read_file's version-0 branch: it serves the unversioned
+            # object directly, ignoring the placeholder manifest — stat must
+            # agree with what a read would actually return.
+            key = filesystem._prefix + "/" + sanitized
+            try:
+                head = filesystem._s3.head_object(Bucket=filesystem._bucket, Key=key)
+            except ClientError as exc:
+                raise NotFound(f"{sanitized} not found in version 0") from exc
+            return {"size": head["ContentLength"],
+                    "content_type": head.get("ContentType", "")}
+        # _get_manifest is private; see the justification on read_all_files.
+        meta = filesystem._get_manifest(v)["files"].get(sanitized)
+        if not meta:
+            raise NotFound(f"{sanitized} not found in version {v}")
+        return {"size": meta["size"], "content_type": meta["content_type"]}
+
+    return await asyncio.to_thread(_sync)
+
+
+async def read_all_files(user_id: str, product_id: str,
+                         version: int | None = None) -> InMemoryFileStore:
+    """Download a version's full file set (the active one when None), entirely
+    off the event loop. Callers that already resolved the active version (the
+    push preflight) pass it to skip re-reading the pointer.
+
+    ``storage.read_all_files_in_memory`` calls the synchronous ``list_files``
+    (blocking S3 round-trips) directly on the event loop, and each of its
+    per-file reads re-resolves the version pointer and manifest — roughly three
+    round-trips per file. Here the pointer and manifest are resolved once in a
+    thread and the objects are fetched concurrently by their manifest keys.
+    """
+    filesystem = _filesystem(user_id, product_id)
+
+    # _get_manifest is private to VersionedR2FileSystem, but it is the single
+    # source of truth for manifest layout; re-fetching and re-parsing the JSON
+    # here would let the two implementations drift (same reasoning as the
+    # _sanitize_path import in router.py).
+    def _resolve() -> dict:
+        return filesystem._get_manifest(
+            filesystem.get_version() if version is None else version)
+
+    manifest = await asyncio.to_thread(_resolve)
+
+    s3 = get_s3_client()
+    # Matches botocore's default max_pool_connections (10): get_s3_client()
+    # uses the default Config, so more in-flight requests than that would
+    # open throwaway connections urllib3 discards with a pool-full warning.
+    sem = asyncio.Semaphore(10)
+
+    async def _read_one(path: str, key: str) -> tuple[str, FileWrite]:
+        def _get() -> FileWrite:
+            obj = s3.get_object(Bucket=Settings.USERS_BUCKET, Key=key)
+            return FileWrite(path, obj["Body"].read(), obj.get("ContentType"))
+
+        async with sem:
+            return path, await asyncio.to_thread(_get)
+
+    pairs = await asyncio.gather(
+        *(_read_one(path, meta["key"]) for path, meta in manifest["files"].items())
+    )
+    return InMemoryFileStore(dict(pairs))

--- a/breba_app/sample.env
+++ b/breba_app/sample.env
@@ -16,3 +16,5 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_TEST_TOKEN=
 GITHUB_TEST_ORG=
+# Optional MCP push API tuning (defaults shown; blank/unset = default)
+#MCP_MAX_FILE_BYTES=20971520

--- a/breba_app/templates/mcp_base.html
+++ b/breba_app/templates/mcp_base.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{# Shared card chrome for the MCP browser-flow pages (consent + message).
+   Page-specific rules go in the mcp_style block. #}
+
+{% block extra_head %}
+<style>
+    body {
+        background-color: #f3f4f6;
+    }
+
+    .mcp-card {
+        max-width: 460px;
+        margin: 4rem auto;
+        background: #fff;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.75rem;
+        padding: 2rem 2.25rem;
+        color: #111827;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+
+    .mcp-card h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+    }
+
+    .mcp-card p {
+        font-size: 0.95rem;
+        color: #374151;
+    }
+</style>
+{% block mcp_style %}{% endblock %}
+{% endblock %}

--- a/breba_app/templates/mcp_consent.html
+++ b/breba_app/templates/mcp_consent.html
@@ -1,0 +1,87 @@
+{% extends "mcp_base.html" %}
+
+{% block title %}Authorize agent · Breba{% endblock %}
+
+{% block mcp_style %}
+<style>
+    .mcp-user {
+        font-weight: 600;
+    }
+
+    .mcp-label {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #374151;
+        margin-bottom: 0.25rem;
+        display: block;
+    }
+
+    .mcp-actions {
+        display: flex;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+    }
+
+    .btn-approve {
+        background-color: #5f31eb;
+        border: none;
+        border-radius: 0.5rem;
+        padding: 0.5rem 1.25rem;
+        font-weight: 500;
+        color: #fff;
+    }
+
+    .btn-approve:hover {
+        background-color: #4b28c4;
+        color: #fff;
+    }
+
+    .btn-deny {
+        background-color: #fff;
+        border: 1px solid #d1d5db;
+        border-radius: 0.5rem;
+        padding: 0.5rem 1.25rem;
+        font-weight: 500;
+        color: #374151;
+    }
+
+    .btn-deny:hover {
+        background-color: #f3f4f6;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mcp-card">
+    <h1>Authorize coding agent</h1>
+    <p>
+        Allow a local coding agent to read and push website files as
+        <span class="mcp-user">{{ username }}</span>. The agent gets a token scoped
+        to the product below — it cannot deploy or change your account.
+    </p>
+
+    <form method="post" action="/mcp/authorize" class="mt-4">
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+        <input type="hidden" name="state" value="{{ state }}">
+        <input type="hidden" name="code_challenge" value="{{ code_challenge }}">
+
+        <label class="mcp-label" for="product_id">Product</label>
+        <select class="form-select" id="product_id" name="product_id" required>
+            {% for product in products %}
+            <option value="{{ product.id }}" {% if product.id == selected_product_id %}selected{% endif %}>
+                {{ product.name }}
+            </option>
+            {% endfor %}
+        </select>
+
+        <div class="mcp-actions">
+            <button type="submit" name="decision" value="approve" class="btn btn-approve">
+                Approve
+            </button>
+            <button type="submit" name="decision" value="deny" class="btn btn-deny">
+                Deny
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/breba_app/templates/mcp_message.html
+++ b/breba_app/templates/mcp_message.html
@@ -1,0 +1,56 @@
+{% extends "mcp_base.html" %}
+
+{% block title %}{{ heading }} · Breba{% endblock %}
+
+{% block mcp_style %}
+<style>
+    .mcp-card {
+        text-align: center;
+    }
+
+    .btn-link-action {
+        display: inline-block;
+        margin-top: 1.25rem;
+        background-color: #5f31eb;
+        border-radius: 0.5rem;
+        padding: 0.5rem 1.25rem;
+        font-weight: 500;
+        color: #fff;
+        text-decoration: none;
+    }
+
+    .btn-link-action:hover {
+        background-color: #4b28c4;
+        color: #fff;
+    }
+
+    .btn-link-secondary {
+        display: block;
+        width: fit-content;
+        margin: 0.75rem auto 0;
+        border: 1px solid #5f31eb;
+        border-radius: 0.5rem;
+        padding: 0.5rem 1.25rem;
+        font-weight: 500;
+        color: #5f31eb;
+        text-decoration: none;
+    }
+
+    .btn-link-secondary:hover {
+        background-color: #f5f3ff;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mcp-card">
+    <h1>{{ heading }}</h1>
+    <p>{{ message }}</p>
+    {% if link_url %}
+    <a class="btn-link-action" href="{{ link_url }}"{% if link_new_tab %} target="_blank" rel="noopener"{% endif %}>{{ link_text or "Continue" }}</a>
+    {% endif %}
+    {% if continue_url %}
+    <a class="btn-link-secondary" href="{{ continue_url }}">{{ continue_text or "Continue" }}</a>
+    {% endif %}
+</div>
+{% endblock %}

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,466 @@
+# breba-mcp — local MCP server
+
+`breba-mcp` lets a local coding agent, such as Claude Code, Codex, Cursor, or
+OpenCode, read and update a **running Breba product**.
+
+The agent works on files locally, then calls `push_site`. Each push creates a
+new revision and rebuilds the preview. The MCP server does **not** create a
+project — create one with the seeding script or in the Breba UI — and it does
+**not** deploy the site; publishing still happens from the Breba UI.
+
+## Quick start
+
+You need a running Breba app. If you do not have one, follow
+[`STANDALONE_SETUP.md`](../STANDALONE_SETUP.md) to bring up a fully local stack
+with no cloud accounts.
+
+The example below uses the stdio transport.
+
+**1. Register the server with your agent.** No environment variables are needed:
+`BREBA_BASE_URL` defaults to `http://localhost:8080` and you pick the product in
+the browser on first use, so the config only needs a name and the command that
+runs the server. For Claude Code, in `<workspace>/.mcp.json` — the directory
+your agent builds the website in, not this repo:
+
+```json
+{
+  "mcpServers": {
+    "breba-site": {
+      "command": "uv",
+      "args": ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+    }
+  }
+}
+```
+
+Other agents take the same command in their own format — see
+[MCP config examples](#mcp-config-examples).
+
+**2. Make the first tool call.** Ask the agent something like *"list the site
+files"*. The server has no token yet, so before it sends the request it opens
+your browser to `/mcp/authorize`. Sign in, pick a product, approve. The token is
+cached at `~/.config/breba-mcp/token.json` and the call proceeds. See
+[Auth](#auth) for later runs and headless use.
+
+**3. Build something.**
+
+> Build me a one-page site for a coffee shop and push it to breba.
+
+The agent generates the files with **its own** LLM and calls `push_site`; the
+Breba app's `OPENAI_API_KEY` is not involved. Each push creates a new revision
+and rebuilds the preview — `get_preview_url()` returns where to look.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `list_site_versions()` | List revisions and show which one is active. |
+| `list_site_files(version?)` | List file paths for a revision. Defaults to the active revision. |
+| `read_site_file(path, version?)` | Read a text file, optionally from a past revision. |
+| `download_site_file(path, dest_path, version?)` | Download one file to a local path. Use this for images, fonts, and other binary files. |
+| `push_site(files)` | Write or overwrite files, creating a new revision and preview. Files not included in the push are preserved. |
+| `get_preview_url()` | Return the URL where you can view the current preview. |
+| `list_products()` | List your products and show which one this MCP session targets. |
+| `switch_product(product_id?)` | Retarget the session. With no argument, opens the browser product picker. |
+
+### Push complete changes
+
+Batch all files for one logical change into a **single** `push_site` call.
+
+Each push creates a user-visible revision and republishes the preview. If an
+agent pushes files one at a time, users may see intermediate broken states, and
+the revision history becomes noisy. If that happens, ask the agent to push all
+the files in one call.
+
+### Binary assets
+
+Binary data never passes through the model context.
+
+Each `push_site` file entry uses one of two shapes:
+
+- `{path, content}` for inline text, such as HTML, CSS, JS, and SVG.
+- `{path, local_path}` for a local file the MCP server reads from disk. Use this
+  for images, fonts, and other binary assets.
+
+In the other direction, `read_site_file` refuses binary content and points the
+agent to `download_site_file`, which writes bytes directly to a local path.
+
+Both directions enforce a per-file size cap with `BREBA_MCP_MAX_FILE_BYTES`
+(default: 20 MB). The Breba app also enforces its own push cap with
+`MCP_MAX_FILE_BYTES`, also 20 MB by default, so direct `/mcp/push` clients are
+bounded too. The limit is therefore enforced on both sides, which guards
+against accidental overuse.
+
+### Past revisions
+
+Past revisions are read-only. Agents can inspect them to recover assets,
+compare design changes, or find when a problem appeared. Any new result still
+has to be written with `push_site`, which always creates a new revision.
+
+There is no rollback tool in MCP. Switching the active version remains a Breba
+UI action.
+
+When an agent reads the active site, its next `push_site` call is guarded by
+that revision. If the site changed through Breba chat or another edit before
+the push, Breba returns a conflict instead of silently overwriting the newer
+file. Re-read the affected files, reapply the change, and push again. Reads of
+an explicit past revision remain reference-only and do not set this guard.
+
+### Project notes (`AGENTS.md`)
+
+Breba stores project notes in `AGENTS.md` alongside the site files. The chat
+agent reads this file on every edit, so MCP agents should keep it current too.
+The MCP server does **not** enforce the use of `AGENTS.md`, and does **not**
+create it on the user's behalf.
+
+Recommended workflow:
+
+1. Read `AGENTS.md` before working: `read_site_file("AGENTS.md")`.
+2. If the file does not exist yet, create it in the first push.
+3. After meaningful changes, include an updated `AGENTS.md` in the same
+   `push_site` call.
+
+Use the file for durable context: user preferences, design decisions,
+constraints, and anything future agents should preserve. `AGENTS.md` versions
+like any other site file, syncs with live chat sessions, and is excluded from
+the built site.
+
+## Auth
+
+The server holds a bearer token scoped to one (user, product) pair, cached at
+`~/.config/breba-mcp/token.json` and good for about 30 days. Whenever it has no
+usable token it runs the browser flow from [Quick start](#quick-start): sign in
+with your existing Breba SSO or local password account, approve, done. Later runs
+reuse the cache; an expired token surfaces as a `401` and starts the same flow
+again.
+
+The cache is keyed by `{base_url, product_id}`, so several agents pointed at the
+same product share one authorization.
+
+### Headless (CI / no browser)
+
+Set `BREBA_MCP_TOKEN` and the server never opens a browser. To get a token,
+complete the browser flow once on a machine that has one, then copy the `token`
+value for your `{base_url}|{product_id}` entry out of
+`~/.config/breba-mcp/token.json`.
+
+## Switching products
+
+You do not have to pin a product in config. Leave `BREBA_PRODUCT_ID` empty,
+pick the product in the browser during first authorization, and switch later by
+asking the agent.
+
+Two tools cover the common flows:
+
+- **"Switch to my cafe site"** — the agent calls `list_products()`, matches the
+  name to an id, and calls `switch_product(product_id)`. A product you
+  authorized before switches instantly; a new one opens the browser once,
+  pre-selected, for consent.
+- **"Let me pick"** — `switch_product()` with no argument always opens the
+  browser product picker, even if a token is cached. This is the escape hatch
+  in pick-in-browser mode, where the cached token would otherwise keep the
+  session on the last-picked product forever.
+
+A switch lasts for the current server process only. With stdio, that means the
+current agent session. With Streamable HTTP, it means all agents connected to
+that long-lived server.
+
+Switching never edits your MCP config and never moves files between products.
+After a restart, the session returns to the product selected by
+`BREBA_PRODUCT_ID`, or to the last picked product from the token cache.
+
+`BREBA_MCP_TOKEN` pins both the token and its product, so `switch_product`
+refuses to run while it is set.
+
+## Transports
+
+- **stdio** (default) — the agent launches the server from its MCP config. You
+  do not run anything separately.
+- **Streamable HTTP** (`--http`) — you run one long-lived server, and agents
+  connect to its URL. See [Connect an agent](#connect-an-agent).
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `BREBA_BASE_URL` | `http://localhost:8080` | Running Breba app, local or cloud. |
+| `BREBA_PRODUCT_ID` | _(empty)_ | Pre-selects a product on the consent page. If empty, you pick one in the browser. |
+| `BREBA_MCP_TOKEN` | _(empty)_ | Pre-supplied bearer token. Skips browser auth for CI or containerized agents. |
+| `BREBA_MCP_CONFIG_DIR` | `~/.config/breba-mcp` | Token cache directory. |
+| `BREBA_MCP_MAX_FILE_BYTES` | `20971520` (20 MB) | Per-file size cap for `push_site` / `download_site_file` |
+
+The **Breba app** reads this additional variable from its own environment.
+It guards `/mcp/push` for every client, not just this MCP server:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `MCP_MAX_FILE_BYTES` | `20971520` (20 MB) | Server-side per-file push cap (`413` above it) |
+
+## Connect an agent
+
+[Quick start](#quick-start) covers the minimal stdio config. With stdio you
+never start the server yourself — the agent does. For Streamable HTTP, start one
+long-lived server by hand and give the agent only its URL:
+
+```bash
+uv --directory <path-to>/disc-site run python -m mcp_server --http --port 8004
+```
+
+The `uv --directory` form works from any working directory.
+
+Env vars then belong to that server process, not to the agent config.
+
+All env vars are optional. A stdio config with every variable spelled out
+(Claude Code format; other agents differ only in file format):
+
+```json
+{
+  "mcpServers": {
+    "breba-site": {
+      "command": "uv",
+      "args": ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"],
+      "env": {
+        "BREBA_BASE_URL": "http://localhost:8080",
+        "BREBA_PRODUCT_ID": "<product_id>",
+        "BREBA_MCP_TOKEN": "<bearer_token>",
+        "BREBA_MCP_CONFIG_DIR": "~/.config/breba-mcp",
+        "BREBA_MCP_MAX_FILE_BYTES": "20971520"
+      }
+    }
+  }
+}
+```
+
+With Streamable HTTP, env vars belong to the server process you start by hand,
+not to the agent config — the agent config only carries the URL.
+
+## MCP config examples
+
+Every example below is the minimum config: no env vars, so `BREBA_BASE_URL`
+defaults to `http://localhost:8080` and you pick the product in the browser
+during first authorization. Add env vars from the
+[Environment variables](#environment-variables) table as needed.
+
+Workspace configs belong in the **agent's workspace** — the directory where
+the agent generates the site — not in this repo.
+
+### Claude Code
+
+Global config: `~/.claude.json` (top-level `mcpServers` object) — or run
+`claude mcp add --scope user breba-site -- uv --directory <path-to>/disc-site run python -m mcp_server`.
+Workspace config: `<workspace>/.mcp.json`. Same content in both.
+
+- <details>
+  <summary>stdio</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "command": "uv",
+        "args": ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+      }
+    }
+  }
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "type": "http",
+        "url": "http://127.0.0.1:8004/mcp"
+      }
+    }
+  }
+  ```
+  </details>
+
+### Codex
+
+Global config: `~/.codex/config.toml`.
+Workspace config: `<workspace>/.codex/config.toml`. Same content in both.
+
+Project-scoped config only loads once the project is **trusted**. Codex asks
+"do you trust the contents of this directory?" the first time you start it
+there; answering yes records
+`[projects."<abs-workspace-path>"] trust_level = "trusted"` in your
+`~/.codex/config.toml`. Until then the workspace file is silently ignored.
+
+- <details>
+  <summary>stdio</summary>
+
+  ```toml
+  [mcp_servers.breba-site]
+  command = "uv"
+  args = ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```toml
+  [mcp_servers.breba-site]
+  url = "http://127.0.0.1:8004/mcp"
+  ```
+  </details>
+
+### agy (Antigravity CLI)
+
+Global config: `~/.gemini/config/mcp_config.json`.
+Workspace config: `<workspace>/.agents/mcp_config.json`. Same content in both;
+add the `breba-site` entry to the `mcpServers` object, or create the file with
+this content if it doesn't exist yet.
+
+- <details>
+  <summary>stdio</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "command": "uv",
+        "args": ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+      }
+    }
+  }
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "type": "http",
+        "url": "http://127.0.0.1:8004/mcp"
+      }
+    }
+  }
+  ```
+  </details>
+
+### Hermes
+
+Global config: `~/.hermes/config.yaml`, which applies to every project.
+Workspace config (workaround): put the same YAML in
+`<workspace>/.hermes/config.yaml` and point `HERMES_HOME` at it with a launch
+wrapper — save this as `<workspace>/hermes-breba.sh`, run `chmod +x` on it,
+and start Hermes through the wrapper:
+
+```bash
+#!/usr/bin/env bash
+export HERMES_HOME="$(cd "$(dirname "$0")" && pwd)/.hermes"
+exec hermes "$@"
+```
+
+- <details>
+  <summary>stdio</summary>
+
+  Add under the `mcp_servers:` key:
+
+  ```yaml
+  mcp_servers:
+    breba-site:
+      command: "uv"
+      args: ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```yaml
+  mcp_servers:
+    breba-site:
+      url: "http://127.0.0.1:8004/mcp"
+  ```
+  </details>
+
+### OpenCode
+
+Global config: `~/.config/opencode/opencode.json`.
+Workspace config: `<workspace>/opencode.json`. Same content in both. OpenCode
+uses a slightly different shape: the key is `mcp` and the command is a single
+array.
+
+- <details>
+  <summary>stdio</summary>
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+      "breba-site": {
+        "type": "local",
+        "command": ["uv", "--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+      "breba-site": {
+        "type": "remote",
+        "url": "http://127.0.0.1:8004/mcp",
+        "enabled": true
+      }
+    }
+  }
+  ```
+  </details>
+
+### Cursor
+
+Same format as Claude Code. Global config: `~/.cursor/mcp.json`.
+Workspace config: `<workspace>/.cursor/mcp.json`. Same content in both.
+
+- <details>
+  <summary>stdio</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "command": "uv",
+        "args": ["--directory", "<path-to>/disc-site", "run", "python", "-m", "mcp_server"]
+      }
+    }
+  }
+  ```
+  </details>
+
+- <details>
+  <summary>Streamable HTTP</summary>
+
+  ```json
+  {
+    "mcpServers": {
+      "breba-site": {
+        "url": "http://127.0.0.1:8004/mcp"
+      }
+    }
+  }
+  ```
+  </details>
+
+**Other agents:** use the same server command (stdio) or server URL (HTTP) in
+whatever MCP config format the agent expects.
+
+**Local LLMs:** agents that run on local models work too — for example, launch
+OpenCode on a local model via Ollama with `ollama launch opencode`.

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,8 @@
+"""Local MCP server that lets a coding agent push a generated site to a running
+Breba product over the headless ``/mcp/*`` HTTP API.
+
+Runs next to the agent (stdio by default). It obtains a bearer token via the
+interactive loopback browser flow (SSO-gated `/mcp/authorize`) on first use and
+caches it; ``BREBA_MCP_TOKEN`` short-circuits the browser for headless/CI use.
+It never deploys — deploy stays a site-UI action.
+"""

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,28 @@
+"""Run the Breba site MCP server.
+
+    uv run python -m mcp_server                  # stdio (Claude Code / Cursor)
+    uv run python -m mcp_server --http --port 8004   # Streamable HTTP at /mcp
+"""
+import argparse
+
+from mcp_server.server import mcp
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="mcp_server", description="Breba site MCP server")
+    parser.add_argument("--http", action="store_true",
+                        help="Serve over Streamable HTTP instead of stdio")
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP bind host")
+    parser.add_argument("--port", type=int, default=8004, help="HTTP bind port")
+    args = parser.parse_args()
+
+    if args.http:
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -1,0 +1,247 @@
+"""Token acquisition for the local MCP server.
+
+Order of precedence when a tool needs a bearer token:
+  1. ``BREBA_MCP_TOKEN`` env var (headless/CI) — used verbatim, never refreshed.
+  2. A non-expired token cached at ``~/.config/breba-mcp/token.json``.
+  3. The interactive loopback browser flow against the product's SSO-gated
+     ``/mcp/authorize`` → single-use ``code`` → ``POST /mcp/token`` → bearer.
+
+A ``token_provider`` is a callable ``(force_refresh: bool) -> str``. The HTTP
+client calls it with ``force_refresh=True`` after a ``401`` to re-run the browser
+flow and retry once.
+"""
+import base64
+import hashlib
+import html
+import json
+import logging
+import os
+import secrets
+import socketserver
+import tempfile
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler
+from typing import Callable
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from mcp_server import config
+
+# Treat a token as expired this many seconds early, to avoid racing the boundary.
+_EXPIRY_SKEW = 30
+
+# Give up on the browser flow after this long, so an abandoned tab (or an error
+# page that never redirects back) can't hang the agent's tool call forever.
+_BROWSER_FLOW_TIMEOUT = 300.0
+_POLL_INTERVAL = 1.0
+
+logger = logging.getLogger(__name__)
+
+TokenProvider = Callable[[bool], str]
+
+
+def _cache_key(base_url: str, product_id: str) -> str:
+    return f"{base_url}|{product_id}"
+
+
+def _read_cache() -> dict:
+    try:
+        return json.loads(config.token_file().read_text())
+    except (json.JSONDecodeError, OSError):  # missing/corrupt file included
+        return {}
+
+
+def _write_cache(data: dict) -> None:
+    """Write the token cache privately (0600) and atomically.
+
+    The file holds long-lived bearer tokens, so it must never be world-readable
+    (cf. gh/aws/gcloud credential files). Writing to a same-directory temp file
+    and ``os.replace``-ing it in means a racing reader never sees a truncated
+    file — a torn read would parse as ``{}`` and a subsequent save would then
+    wipe every other cached token.
+    """
+    cfg_dir = config.config_dir()
+    cfg_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path = config.token_file()
+    fd, tmp = tempfile.mkstemp(dir=cfg_dir, prefix=f".{path.name}.")  # 0600 by mkstemp
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(data, indent=2))
+        os.replace(tmp, path)  # atomic; the file inherits the temp's 0600 mode
+    except BaseException:
+        os.unlink(tmp)
+        raise
+
+
+def load_cached_token(base_url: str, product_id: str) -> str | None:
+    entry = _read_cache().get(_cache_key(base_url, product_id))
+    if not entry:
+        return None
+    if entry.get("expires_at", 0) <= time.time() + _EXPIRY_SKEW:
+        return None
+    return entry.get("token")
+
+
+def save_token(base_url: str, product_id: str, token: str, expires_at: float) -> None:
+    data = _read_cache()
+    data[_cache_key(base_url, product_id)] = {"token": token, "expires_at": expires_at}
+    _write_cache(data)
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 (stdlib naming)
+        parsed = urlparse(self.path)
+        if parsed.path != "/callback":
+            self.send_response(404)
+            self.end_headers()
+            return
+        query = parse_qs(parsed.query)
+        if "code" not in query and "error" not in query:
+            # A stray probe (security software, browser extension, curl) with
+            # neither outcome parameter is not the authorize redirect: answer
+            # it without recording, so the wait loop keeps listening for the
+            # real callback instead of aborting on a spurious state mismatch.
+            self.send_response(204)
+            self.end_headers()
+            return
+        self.server.callback_query = query
+        if "error" in query:
+            detail = query.get("error_description", query["error"])[0]
+            message = f"Authorization failed: {html.escape(detail)}"
+        else:
+            message = "Authorization complete. You can close this window."
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(
+            f"<html><body><p>{message}</p>"
+            "<script>window.close()</script></body></html>".encode()
+        )
+
+    def log_message(self, *args):  # silence the default stderr logging
+        pass
+
+
+def _await_authorization_code(server: socketserver.TCPServer, auth_url: str,
+                              state: str, timeout: float) -> str:
+    """Open the browser, wait for the loopback callback, and return the code.
+
+    Validates the callback: an ``error`` redirect or a ``state`` mismatch
+    raises, as does hitting ``timeout`` before any callback arrives.
+    """
+    deadline = time.monotonic() + timeout
+    try:
+        # The agent driving this stdio server never sees stderr, and the user
+        # watching the browser doesn't need the URL — keep it as a log
+        # breadcrumb only.
+        logger.info("Opening browser to authorize: %s", auth_url)
+        if not webbrowser.open(auth_url):
+            raise RuntimeError(
+                "Could not open a browser for the authorization flow on this "
+                "machine. Authorize once on a machine with a browser (run this "
+                "MCP server there against the same BREBA_BASE_URL), copy the "
+                "token from ~/.config/breba-mcp/token.json, and set it here as "
+                "BREBA_MCP_TOKEN."
+            )
+        while server.callback_query is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"Authorization timed out after {int(timeout)}s waiting for the "
+                    "browser callback. Complete the sign-in/consent in the browser "
+                    "(and check BREBA_PRODUCT_ID), then retry."
+                )
+            server.timeout = min(_POLL_INTERVAL, remaining)
+            server.handle_request()  # one request at a time; ignores favicon etc.
+    finally:
+        server.server_close()
+
+    query = server.callback_query
+    if "error" in query:
+        error = query["error"][0]
+        detail = query.get("error_description", [""])[0]
+        raise RuntimeError(
+            f"Authorization failed ({error})" + (f": {detail}" if detail else "")
+        )
+    if query.get("state", [None])[0] != state:
+        raise RuntimeError("State mismatch in authorization callback (possible CSRF).")
+    return query["code"][0]
+
+
+def obtain_token_via_browser(base_url: str, product_id: str,
+                             timeout: float = _BROWSER_FLOW_TIMEOUT) -> dict:
+    """Run the loopback browser flow; return {"token", "product_id", "expires_at"}.
+
+    ``product_id`` may be empty — the user then picks the product on the consent
+    page, and the returned ``product_id`` is the one actually picked. The token is
+    cached under the *picked* product id only: it is scoped to that product, so
+    caching it under a differing requested id would make later lookups for the
+    requested product silently operate on the picked one. In pick-in-browser mode
+    (empty ``product_id``) it is additionally cached under the empty key, so the
+    next session without ``BREBA_PRODUCT_ID`` reuses the last pick without a
+    browser round-trip.
+    """
+    server = socketserver.TCPServer(("127.0.0.1", 0), _CallbackHandler)
+    server.callback_query = None
+    port = server.server_address[1]
+    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    # 16 bytes = 128 bits, the conventional size for an unguessable CSRF token.
+    state = secrets.token_urlsafe(16)
+    # PKCE (RFC 7636, S256): the verifier never leaves this process, so a code
+    # intercepted between browser and loopback can't be exchanged without it.
+    # 48 bytes encode to 64 chars, inside the 43-128 the RFC requires (32 bytes
+    # would sit exactly at the 43-char minimum).
+    code_verifier = secrets.token_urlsafe(48)
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+
+    params = {"redirect_uri": redirect_uri, "state": state,
+              "code_challenge": code_challenge}
+    if product_id:
+        params["product_id"] = product_id
+    auth_url = f"{base_url}/mcp/authorize?{urlencode(params)}"
+
+    code = _await_authorization_code(server, auth_url, state, timeout)
+
+    resp = httpx.post(f"{base_url}/mcp/token",
+                      json={"code": code, "code_verifier": code_verifier}, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    picked = data.get("product_id") or product_id
+    save_token(base_url, picked, data["token"], data["expires_at"])
+    if not product_id and picked:
+        # Pick-in-browser mode: also cache under the "no product configured" key.
+        save_token(base_url, "", data["token"], data["expires_at"])
+    return {"token": data["token"], "product_id": picked, "expires_at": data["expires_at"]}
+
+
+def make_token_provider(
+    base_url: str, product_id: str,
+    on_product_change: Callable[[str], None] | None = None,
+) -> TokenProvider:
+    """Build a TokenProvider for ``product_id`` on ``base_url``.
+
+    The consent page's product picker stays editable even when the flow
+    requested a specific product, so the user may approve a *different* one.
+    That pick is authoritative: the returned token is scoped to it, and it is
+    cached under the picked id only. When that happens, ``on_product_change``
+    is called with the picked id so the caller can retarget its session to
+    match the token it is about to use.
+    """
+    def provider(force_refresh: bool = False) -> str:
+        token = config.env_token()
+        if token:
+            return token  # user-supplied; cannot be refreshed
+        if not force_refresh:
+            cached = load_cached_token(base_url, product_id)
+            if cached:
+                return cached
+        result = obtain_token_via_browser(base_url, product_id)
+        if result["product_id"] != product_id and on_product_change is not None:
+            on_product_change(result["product_id"])
+        return result["token"]
+
+    return provider

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -1,0 +1,82 @@
+"""Thin HTTP client for the product's ``/mcp/*`` API.
+
+Attaches ``Authorization: Bearer <token>`` from the token provider. On a ``401``
+it forces a token refresh (the loopback browser flow) and retries the request
+once, so the agent's first tool call transparently triggers sign-in.
+
+Each instance holds one ``httpx.Client``, so consecutive tool calls reuse the
+same TCP/TLS connection instead of paying a fresh handshake per request. The
+pool lives for the process (one agent session); it is not explicitly closed.
+"""
+import httpx
+
+from mcp_server.auth import TokenProvider
+
+
+class SiteApiError(RuntimeError):
+    """API call failed; ``status_code`` lets callers react per HTTP status."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class SiteClient:
+    def __init__(self, base_url: str, token_provider: TokenProvider, timeout: float = 60.0):
+        self._token_provider = token_provider
+        self._http = httpx.Client(base_url=base_url, timeout=timeout)
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        def call(token: str) -> httpx.Response:
+            return self._http.request(
+                method, path,
+                headers={"Authorization": f"Bearer {token}"}, **kwargs,
+            )
+
+        resp = call(self._token_provider(False))
+        if resp.status_code == 401:
+            resp = call(self._token_provider(True))  # re-auth via browser, retry once
+        if resp.status_code >= 400:
+            raise SiteApiError(f"{method} {path} -> {resp.status_code}: {resp.text}",
+                               resp.status_code)
+        return resp.json()
+
+    def ensure_auth(self) -> None:
+        """Acquire a token now (cached, or the browser flow on first use).
+
+        Lets callers force auth side effects — notably a consent-picker product
+        switch retargeting the session — to happen *before* they read session
+        state that depends on the target product.
+        """
+        self._token_provider(False)
+
+    def list_versions(self) -> dict:
+        return self._request("GET", "/mcp/versions")
+
+    def list_files(self, version: int | None = None) -> dict:
+        params = {} if version is None else {"version": version}
+        return self._request("GET", "/mcp/files", params=params)
+
+    def read_file(self, path: str, version: int | None = None) -> dict:
+        params: dict = {"path": path}
+        if version is not None:
+            params["version"] = version
+        return self._request("GET", "/mcp/file", params=params)
+
+    def stat_file(self, path: str, version: int | None = None) -> dict:
+        params: dict = {"path": path}
+        if version is not None:
+            params["version"] = version
+        return self._request("GET", "/mcp/file/stat", params=params)
+
+    def push(self, files: list[dict], expected_version: int | None = None) -> dict:
+        body: dict = {"files": files}
+        if expected_version is not None:
+            body["expected_version"] = expected_version
+        return self._request("POST", "/mcp/push", json=body)
+
+    def preview(self) -> dict:
+        return self._request("GET", "/mcp/preview")
+
+    def products(self) -> dict:
+        return self._request("GET", "/mcp/products")

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -1,0 +1,40 @@
+"""Environment-driven configuration for the local MCP server.
+
+Read at call time (not import time) so tests can set env vars per-case.
+"""
+import os
+from pathlib import Path
+
+
+def base_url() -> str:
+    """Base URL of the running Breba product (local or cloud)."""
+    return os.environ.get("BREBA_BASE_URL", "http://localhost:8080").rstrip("/")
+
+
+def product_id() -> str:
+    """Default product to pre-select in the consent page (optional).
+
+    The data endpoints derive the product from the token, so this only seeds the
+    `/mcp/authorize` URL; when empty the user picks a product in the browser.
+    """
+    return os.environ.get("BREBA_PRODUCT_ID", "")
+
+
+def env_token() -> str:
+    """A pre-supplied bearer token for headless/CI use; skips the browser flow."""
+    return os.environ.get("BREBA_MCP_TOKEN", "")
+
+
+def max_file_bytes() -> int:
+    """Per-file size cap for ``push_site``/``download_site_file`` (bytes)."""
+    # `or`: a blank value (`VAR=` line in a .env) counts as unset, not int("").
+    return int(os.environ.get("BREBA_MCP_MAX_FILE_BYTES") or 20 * 1024 * 1024)
+
+
+def config_dir() -> Path:
+    default = Path.home() / ".config" / "breba-mcp"
+    return Path(os.environ.get("BREBA_MCP_CONFIG_DIR", str(default))).expanduser()
+
+
+def token_file() -> Path:
+    return config_dir() / "token.json"

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,340 @@
+"""FastMCP server exposing the site push/read tools to a local coding agent.
+
+Tools are synchronous: the auth path may block on a browser/loopback round-trip,
+which is simplest to express synchronously. There is intentionally **no
+``deploy_site`` tool** — going live is a site-UI action.
+"""
+import base64
+import mimetypes
+from pathlib import Path
+
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import BaseModel, model_validator
+
+from mcp_server import config
+from mcp_server.auth import load_cached_token, make_token_provider, obtain_token_via_browser
+from mcp_server.client import SiteApiError, SiteClient
+
+mcp = FastMCP("breba-site")
+
+# Runtime target set by ``switch_product``; None means "use BREBA_PRODUCT_ID".
+# Per-process, so a switch lasts for this server's lifetime — one agent session
+# over stdio, every connected agent over --http.
+_product_override: str | None = None
+
+
+def _active_product_id() -> str:
+    return config.product_id() if _product_override is None else _product_override
+
+
+def _adopt_picked_product(picked: str) -> None:
+    """Retarget the session when the consent page's picker chose another product.
+
+    The picker stays editable even when a specific product was requested; the
+    user's pick is authoritative — the token in hand is scoped to it — so the
+    session must follow, or every later call would target the old product,
+    cache-miss, and re-open the browser.
+    """
+    global _product_override
+    _product_override = picked
+
+
+# One SiteClient — and thus one persistent HTTP connection pool — per
+# (base_url, product) target; a product switch lazily creates the next one.
+_clients: dict[tuple[str, str], SiteClient] = {}
+
+# Latest active revision observed per agent session and target. A push carries
+# it as an optimistic-concurrency precondition so an agent cannot silently
+# overwrite a browser/chat edit made after its read. Keyed by the MCP session
+# — over --http each connected agent has its own — so one agent's fresher read
+# cannot re-arm another agent's stale push. Historical reads intentionally do
+# not update this value: they are often used as reference material, not as the
+# edit base. Entries for closed sessions are a few ints; left to process exit.
+_observed_versions: dict[tuple, int] = {}
+
+
+def _guard_key(ctx: Context | None) -> tuple:
+    # Direct calls (tests) pass no ctx; stdio has a single session anyway.
+    session = id(ctx.session) if ctx is not None else None
+    return session, config.base_url(), _active_product_id()
+
+
+def _remember_active_version(ctx: Context | None, version: int | None) -> None:
+    if version is not None:
+        _observed_versions[_guard_key(ctx)] = version
+
+
+def _client() -> SiteClient:
+    base = config.base_url()
+    key = (base, _active_product_id())
+    if key not in _clients:
+        provider = make_token_provider(base, key[1],
+                                       on_product_change=_adopt_picked_product)
+        _clients[key] = SiteClient(base, provider)
+    return _clients[key]
+
+
+def _check_cap(size: int, what: str) -> None:
+    cap = config.max_file_bytes()
+    if size > cap:
+        raise ValueError(
+            f"{what} is {size} bytes; the per-file cap is {cap} bytes "
+            "(override with BREBA_MCP_MAX_FILE_BYTES)."
+        )
+
+
+# Non-"text/*" content types that are still safe to hand to the model as text.
+_TEXT_CONTENT_TYPES = {
+    "application/json", "application/javascript", "application/x-javascript",
+    "application/ecmascript", "application/xml",
+}
+
+
+def _is_text_content_type(content_type: str) -> bool:
+    if not content_type:
+        return True  # unknown: let the UTF-8 decode backstop decide
+    ct = content_type.split(";")[0].strip().lower()
+    return (ct.startswith("text/") or ct in _TEXT_CONTENT_TYPES
+            or ct.endswith("+json") or ct.endswith("+xml"))  # e.g. image/svg+xml
+
+
+def _fetch_file(client: SiteClient, path: str, version: int | None,
+                ctx: Context | None) -> tuple[str, bytes]:
+    """Fetch one file's bytes: read, version-guard update, cap backstop.
+
+    The guard updates before the cap backstop below: the active revision was
+    observed by the read itself, whether or not the content turns out usable.
+    The backstop re-checks the real size because version-0 manifests report
+    size 0, which makes the callers' pre-download stat checks vacuous.
+    """
+    data = client.read_file(path, version)
+    if version is None:
+        _remember_active_version(ctx, data.get("version"))
+    raw = base64.b64decode(data["content_b64"])
+    _check_cap(len(raw), f"Site file '{data['path']}'")
+    return data["path"], raw
+
+
+class FileArg(BaseModel):
+    path: str
+    content: str | None = None  # text files: inline content, base64-encoded on the wire
+    local_path: str | None = None  # binary assets: local file whose bytes are read by the server
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self):
+        if (self.content is None) == (self.local_path is None):
+            raise ValueError(
+                "Provide exactly one of 'content' (inline text) or "
+                "'local_path' (local file to read bytes from)."
+            )
+        return self
+
+
+@mcp.tool()
+def list_site_versions(ctx: Context = None) -> dict:
+    """List all site revision numbers and which one is active.
+
+    Every push creates a new revision; older ones stay readable via the
+    ``version`` argument of ``list_site_files``/``read_site_file``. Use this to
+    review the site's history — e.g. to combine elements from different
+    revisions into a new push, or to understand how a design evolved.
+    Returns {"versions", "active"}.
+    """
+    result = _client().list_versions()
+    _remember_active_version(ctx, result.get("active"))
+    return result
+
+
+@mcp.tool()
+def list_site_files(version: int | None = None, ctx: Context = None) -> dict:
+    """List the file paths of a site revision (the active one by default)."""
+    result = _client().list_files(version)
+    if version is None:
+        _remember_active_version(ctx, result.get("version"))
+    return result
+
+
+@mcp.tool()
+def read_site_file(path: str, version: int | None = None, ctx: Context = None) -> dict:
+    """Read one site file, from the active revision or an older one.
+
+    Pass ``version`` (see ``list_site_versions``) to read a past revision —
+    e.g. to pull the background styling from version 5 and the artwork from
+    version 9 into a new push. Returns {"path", "content"} with decoded text.
+
+    Text files only: reading a binary file (image, font) fails with a pointer to
+    ``download_site_file``, which saves the bytes to a local path instead.
+    """
+    client = _client()
+    # Metadata first: refuse known-binary or oversized files before paying for
+    # (and then discarding) the whole download.
+    info = client.stat_file(path, version)
+    if not _is_text_content_type(info.get("content_type", "")):
+        raise ValueError(
+            f"'{path}' is a binary file ({info['content_type']}, {info['size']} bytes); "
+            "use download_site_file to save it to a local path instead."
+        )
+    _check_cap(info.get("size", 0), f"Site file '{path}'")
+    server_path, raw = _fetch_file(client, path, version, ctx)
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # Backstop for unknown/lying content types.
+        raise ValueError(
+            f"'{server_path}' is a binary file ({len(raw)} bytes); "
+            "use download_site_file to save it to a local path instead."
+        ) from exc
+    return {"path": server_path, "content": content}
+
+
+@mcp.tool()
+def download_site_file(path: str, dest_path: str, version: int | None = None,
+                       ctx: Context = None) -> dict:
+    """Download one site file (binary-safe) to a local path.
+
+    Use this for images, fonts, and other binary assets that ``read_site_file``
+    refuses: the bytes go straight from the site to ``dest_path`` on disk without
+    entering the conversation. Parent directories are created as needed. Pass
+    ``version`` to download from a past revision.
+    Returns {"path", "dest_path", "size"}.
+    """
+    client = _client()
+    # Refuse on the manifest size before downloading; _fetch_file keeps the
+    # post-download backstop. Its guard update matters here too: a binary asset
+    # read from the active revision is an edit base like any text read, and
+    # without it a download-only session would push unguarded.
+    _check_cap(client.stat_file(path, version).get("size", 0), f"Site file '{path}'")
+    server_path, raw = _fetch_file(client, path, version, ctx)
+    dest = Path(dest_path).expanduser()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(raw)
+    return {"path": server_path, "dest_path": str(dest), "size": len(raw)}
+
+
+@mcp.tool()
+def push_site(files: list[FileArg], ctx: Context = None) -> dict:
+    """Write/overwrite the given files as a new site revision and rebuild the preview.
+
+    Batch every file of one logical change into a SINGLE call — never call this
+    once per file. Each call creates a user-visible revision and republishes the
+    preview, so a split push shows visitors intermediate, possibly broken states.
+    Unpushed files are preserved, never deleted, so a push only needs the files
+    the change touches. This does NOT deploy/go-live.
+    After an active-revision read, Breba rejects the push if another edit has
+    created a newer revision; re-read and reapply the change, then retry.
+    Returns {"version", "product_id"}.
+
+    Each file gives its content one of two ways:
+    - ``content`` — inline text (HTML/CSS/JS/SVG/…).
+    - ``local_path`` — a local file whose bytes the server reads from disk.
+      Pass an absolute path: the server's working directory is not the agent's.
+      Use this for binary assets (images, fonts): never paste binary or base64
+      data into ``content``.
+
+    Maintain the project notes: read ``AGENTS.md`` before working (a new site
+    may not have one yet — create it with your first push), and after
+    meaningful changes include an updated ``AGENTS.md`` recording the decisions
+    and constraints behind them — the site's chat agent reads and extends the
+    same file, so this keeps the two in sync.
+    """
+    payload = []
+    for f in files:
+        content_type = None
+        if f.content is not None:
+            raw = f.content.encode()
+            # Inline content is text by definition. Without an explicit type,
+            # the server guesses from the extension and stamps extensionless
+            # files (CNAME, LICENSE) application/octet-stream — read_site_file
+            # would then refuse to read back a file this tool pushed as text.
+            content_type = mimetypes.guess_type(f.path)[0] or "text/plain"
+        else:
+            p = Path(f.local_path).expanduser()
+            if not p.is_file():
+                raise ValueError(f"Local file not found: {f.local_path}")
+            # stat before read: never load an oversized file into memory
+            _check_cap(p.stat().st_size, f.local_path)
+            raw = p.read_bytes()
+        _check_cap(len(raw), f"'{f.path}'")
+        entry = {"path": f.path, "content_b64": base64.b64encode(raw).decode()}
+        if content_type is not None:
+            entry["content_type"] = content_type
+        payload.append(entry)
+    # First-use auth (and any consent-picker product switch it triggers) must
+    # complete before the guard is read, or the push would carry a revision
+    # observed on the product the session just switched away from. A token
+    # expiring between here and the request can still reopen that window, but
+    # for seconds rather than for the whole first-auth browser flow.
+    _client().ensure_auth()
+    key = _guard_key(ctx)  # after auth: the switch, if any, has happened
+    expected_version = _observed_versions.get(key)
+    try:
+        # SiteClient.push omits the field when expected_version is None, so the
+        # unguarded payload stays byte-identical to the pre-guard wire format.
+        result = _client().push(payload, expected_version=expected_version)
+    except SiteApiError as e:
+        # A non-409 failure may still have saved a new revision (the router
+        # 500s when the preview rebuild fails *after* the save advanced the
+        # active pointer). The remembered version is then stale and would
+        # deterministically 409 the follow-up push the error asks for, so
+        # forget it — the next push runs unguarded, as before any read.
+        # A 409 keeps the guard: its re-read/reapply recovery refreshes it.
+        if e.status_code != 409:
+            _observed_versions.pop(key, None)
+        raise
+    _remember_active_version(ctx, result.get("version"))
+    return result
+
+
+@mcp.tool()
+def get_preview_url() -> dict:
+    """Return the preview URL for the current site revision."""
+    return _client().preview()
+
+
+@mcp.tool()
+def list_products() -> dict:
+    """List the user's products (their websites) and which one this session targets.
+
+    Use this when the user names a product/project/site: find its ``id`` here,
+    then pass it to ``switch_product``. Returns
+    {"products": [{"id", "name"}, ...], "current": <product_id>}.
+    """
+    return _client().products()
+
+
+@mcp.tool()
+def switch_product(product_id: str = "") -> dict:
+    """Switch this session to another product (website); every site tool then targets it.
+
+    Two modes:
+    - ``product_id`` given — switch directly (map a product *name* to its id via
+      ``list_products`` first). A previously authorized product switches without
+      a browser round-trip; otherwise the browser opens pre-selected for consent.
+    - ``product_id`` empty — always opens the browser so the user picks the
+      product there. Use this when the user wants to choose interactively.
+
+    The switch lasts for this server process only; it does not change the
+    ``BREBA_PRODUCT_ID`` in the agent's MCP config.
+    Returns {"product_id", "name"} of the new target.
+    """
+    global _product_override
+    if config.env_token():
+        raise ValueError(
+            "BREBA_MCP_TOKEN is set, which pins both the token and its product; "
+            "unset it (or supply a token for the other product) to switch."
+        )
+    base = config.base_url()
+    if product_id and load_cached_token(base, product_id):
+        # Previously authorized: switch silently, no browser round-trip.
+        _product_override = product_id
+    else:
+        # The browser flow's consent picker stays editable even when a specific
+        # product was requested, so the user's pick — which the token in hand
+        # is scoped to — wins over the requested id. The override commits only
+        # once a token is actually in hand: a failed flow raises above this.
+        _product_override = obtain_token_via_browser(base, product_id)["product_id"]
+
+    info = _client().products()  # proves the token works and resolves the display name
+    current = info["current"]
+    name = next((p["name"] for p in info["products"] if p["id"] == current), current)
+    return {"product_id": current, "name": name}

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -1,0 +1,700 @@
+import asyncio
+import base64
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from breba_app.filesystem.in_memory_store import InMemoryFileStore
+from breba_app.filesystem.models import FileWrite
+from breba_app.filesystem.versioned_r2 import NotFound
+from breba_app.mcp_api import auth
+from breba_app.mcp_api import store as store_module
+from breba_app.mcp_api.router import router
+
+SECRET = "test-secret"
+USER_ID = "user-1"
+PRODUCT_ID = "prod-1"
+
+
+@pytest.fixture(autouse=True)
+def _secret(monkeypatch):
+    monkeypatch.setenv("CHAINLIT_AUTH_SECRET", SECRET)
+
+
+# --- auth.py: stateless HMAC token signing -----------------------------------
+
+def test_token_roundtrip():
+    tok = auth.mint_token(USER_ID, PRODUCT_ID)[0]
+    data = auth.verify_token(tok)
+    assert data["user_id"] == USER_ID
+    assert data["product_id"] == PRODUCT_ID
+
+
+def test_tampered_token_rejected():
+    tok = auth.mint_token(USER_ID, PRODUCT_ID)[0]
+    body, sig = tok.split(".", 1)
+    tampered = f"{body}.{'0' * len(sig)}"
+    assert auth.verify_token(tampered) is None
+
+
+def test_expired_token_rejected():
+    tok = auth.mint_token(USER_ID, PRODUCT_ID, ttl=-10)[0]
+    assert auth.verify_token(tok) is None
+
+
+def test_code_and_token_kinds_dont_cross_validate():
+    # A short-lived browser code must not be accepted as a bearer token, and vice versa.
+    assert auth.verify_token(auth.mint_code(USER_ID, PRODUCT_ID)) is None
+    assert auth.verify_code(auth.mint_token(USER_ID, PRODUCT_ID)[0]) is None
+
+
+def test_malformed_token_rejected():
+    assert auth.verify_token("not-a-token") is None
+
+
+def test_verify_without_secret_raises_instead_of_401(monkeypatch):
+    # A missing CHAINLIT_AUTH_SECRET is misconfiguration and must surface loudly,
+    # not masquerade as an invalid token.
+    tok = auth.mint_token(USER_ID, PRODUCT_ID)[0]
+    monkeypatch.delenv("CHAINLIT_AUTH_SECRET")
+    with pytest.raises(RuntimeError, match="CHAINLIT_AUTH_SECRET"):
+        auth.verify_token(tok)
+
+
+# --- router.py: headless push API --------------------------------------------
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture
+def bearer():
+    return {"Authorization": f"Bearer {auth.mint_token(USER_ID, PRODUCT_ID)[0]}"}
+
+
+@pytest.fixture
+def existing_store(mocker):
+    """Patch storage so the product exists with two files already on it."""
+    store = InMemoryFileStore()
+    store.write_bytes("index.html", b"<old>")
+    store.write_bytes("styles.css", b"body{}")
+    product = mocker.patch("breba_app.mcp_api.router.Product")
+    product.find_one = mocker.AsyncMock(return_value=object())  # product exists
+
+    # /mcp/files and /mcp/file read via the targeted store helpers, not a full
+    # download. The helpers resolve version=None to the active version (0 here)
+    # and return it alongside the payload.
+    async def _list_files(user_id, product_id, version=None):
+        return store.list_files(), 0 if version is None else version
+
+    async def _read_file(user_id, product_id, path, version=None):
+        if not store.file_exists(path):
+            raise NotFound(f"{path} not found in version {version}")
+        return FileWrite(path=path, content=store.read_bytes(path)), 0 if version is None else version
+
+    mocker.patch("breba_app.mcp_api.store.list_files", mocker.AsyncMock(side_effect=_list_files))
+    mocker.patch("breba_app.mcp_api.store.read_file", mocker.AsyncMock(side_effect=_read_file))
+    mocker.patch("breba_app.mcp_api.store.read_all_files",
+                 mocker.AsyncMock(return_value=store))
+    mocker.patch("breba_app.mcp_api.router.get_active_version", mocker.AsyncMock(return_value=0))
+    save = mocker.patch("breba_app.mcp_api.router.save_files",
+                        mocker.AsyncMock(return_value=7))
+    mocker.patch("breba_app.mcp_api.router.build_preview_incremental", mocker.AsyncMock())
+    mocker.patch("breba_app.mcp_api.router.get_index_html_path",
+                 return_value="http://prod-1.localhost:8088/index.html")
+    return store, save
+
+
+def test_unauthenticated_request_is_401_with_pointer(client):
+    resp = client.get("/mcp/files")
+    assert resp.status_code == 401
+    assert "/mcp/authorize" in resp.headers.get("WWW-Authenticate", "")
+
+
+def test_list_files(client, bearer, existing_store):
+    resp = client.get("/mcp/files", headers=bearer)
+    assert resp.status_code == 200
+    assert resp.json() == {"files": ["index.html", "styles.css"], "version": 0}
+
+
+def test_read_file(client, bearer, existing_store):
+    resp = client.get("/mcp/file", params={"path": "index.html"}, headers=bearer)
+    assert resp.status_code == 200
+    assert base64.b64decode(resp.json()["content_b64"]) == b"<old>"
+    assert resp.json()["version"] == 0
+
+
+def test_read_missing_file_is_404(client, bearer, existing_store):
+    resp = client.get("/mcp/file", params={"path": "nope.html"}, headers=bearer)
+    assert resp.status_code == 404
+    assert "nope.html" in resp.json()["detail"]
+
+
+def test_list_versions(client, bearer, mocker):
+    mocker.patch("breba_app.mcp_api.router.list_versions",
+                 mocker.AsyncMock(return_value=[0, 1, 2, 3]))
+    mocker.patch("breba_app.mcp_api.router.get_active_version",
+                 mocker.AsyncMock(return_value=3))
+    resp = client.get("/mcp/versions", headers=bearer)
+    assert resp.status_code == 200
+    assert resp.json() == {"versions": [0, 1, 2, 3], "active": 3}
+
+
+def test_read_file_from_specific_version(client, bearer, mocker):
+    read_file = mocker.patch(
+        "breba_app.mcp_api.store.read_file",
+        mocker.AsyncMock(return_value=(FileWrite(path="index.html", content=b"<v5>"), 5)))
+    resp = client.get("/mcp/file", params={"path": "index.html", "version": 5}, headers=bearer)
+    assert resp.status_code == 200
+    assert base64.b64decode(resp.json()["content_b64"]) == b"<v5>"
+    assert resp.json()["version"] == 5
+    read_file.assert_awaited_once_with(USER_ID, PRODUCT_ID, "index.html", 5)
+
+
+def test_nonexistent_version_is_404(client, bearer, mocker):
+    mocker.patch("breba_app.mcp_api.store.list_files",
+                 mocker.AsyncMock(side_effect=NotFound("Version 99 does not exist")))
+    resp = client.get("/mcp/files", params={"version": 99}, headers=bearer)
+    assert resp.status_code == 404
+    assert "99" in resp.json()["detail"]
+
+
+def test_missing_active_manifest_404_names_the_resolved_version(client, bearer, mocker):
+    # No version param: the store resolves the active pointer to 3, whose
+    # manifest is gone; its NotFound names 3, and the 404 must relay that
+    # rather than report the never-passed request parameter.
+    mocker.patch("breba_app.mcp_api.store.list_files",
+                 mocker.AsyncMock(side_effect=NotFound("Version 3 does not exist")))
+    resp = client.get("/mcp/files", headers=bearer)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Version 3 does not exist"
+
+
+def test_push_merges_and_preserves_unpushed_files(client, bearer, existing_store):
+    store, save = existing_store
+    new_html = base64.b64encode(b"<new>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": new_html}]})
+    assert resp.status_code == 200
+    assert resp.json() == {"version": 7, "product_id": PRODUCT_ID}
+
+    # Merge-only contract: only the pushed file is written; the unpushed file is
+    # preserved by the manifest merge in batch_write, not by re-saving the snapshot.
+    saved = save.call_args.args[2]
+    assert [(fw.path, fw.content) for fw in saved] == [("index.html", b"<new>")]
+    # The preview store still holds the full merged state.
+    assert store.read_bytes("index.html") == b"<new>"
+    assert store.read_bytes("styles.css") == b"body{}"
+
+
+def test_push_rejects_an_outdated_expected_version(client, bearer, existing_store, mocker):
+    _, save = existing_store
+    mocker.patch("breba_app.mcp_api.router.get_active_version", mocker.AsyncMock(return_value=4))
+    preview = mocker.patch("breba_app.mcp_api.router.build_preview_incremental", mocker.AsyncMock())
+    content = base64.b64encode(b"<new>").decode()
+
+    resp = client.post(
+        "/mcp/push", headers=bearer,
+        json={"files": [{"path": "index.html", "content_b64": content}], "expected_version": 3},
+    )
+
+    assert resp.status_code == 409
+    assert "changed from revision 3 to 4" in resp.json()["detail"]
+    save.assert_not_called()
+    preview.assert_not_called()
+
+
+def test_unguarded_push_skips_the_version_lookup(client, bearer, existing_store, mocker):
+    gav = mocker.patch("breba_app.mcp_api.router.get_active_version",
+                       mocker.AsyncMock(return_value=4))
+    content = base64.b64encode(b"<new>").decode()
+
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": content}]})
+
+    assert resp.status_code == 200
+    gav.assert_not_awaited()
+
+
+def test_push_accepts_the_current_expected_version(client, bearer, existing_store, mocker):
+    _, save = existing_store
+    mocker.patch("breba_app.mcp_api.router.get_active_version", mocker.AsyncMock(return_value=4))
+    content = base64.b64encode(b"<new>").decode()
+
+    resp = client.post(
+        "/mcp/push", headers=bearer,
+        json={"files": [{"path": "index.html", "content_b64": content}], "expected_version": 4},
+    )
+
+    assert resp.status_code == 200
+    save.assert_awaited_once()
+
+
+@pytest.mark.parametrize("bad_path", ["../evil.html", "a/../evil.html", "bad\x00name.html", "dir/", ""])
+def test_push_invalid_path_is_400_with_no_side_effects(client, bearer, existing_store, mocker, bad_path):
+    _, save = existing_store
+    preview = mocker.patch("breba_app.mcp_api.router.build_preview_incremental", mocker.AsyncMock())
+    content = base64.b64encode(b"x").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": bad_path, "content_b64": content}]})
+    assert resp.status_code == 400
+    assert bad_path in resp.json()["detail"]
+    save.assert_not_called()
+    preview.assert_not_called()
+
+
+def test_push_uses_sanitized_paths(client, bearer, existing_store):
+    _, save = existing_store
+    content = base64.b64encode(b"x").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "./css//styles.css", "content_b64": content}]})
+    assert resp.status_code == 200
+    assert [fw.path for fw in save.call_args.args[2]] == ["css/styles.css"]
+
+
+def test_push_oversized_file_is_413_with_no_side_effects(client, bearer, existing_store, mocker, monkeypatch):
+    _, save = existing_store
+    preview = mocker.patch("breba_app.mcp_api.router.build_preview_incremental", mocker.AsyncMock())
+    monkeypatch.setenv("MCP_MAX_FILE_BYTES", "10")
+    small = base64.b64encode(b"y" * 10).decode()
+    big = base64.b64encode(b"x" * 11).decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "ok.css", "content_b64": small},
+                                       {"path": "big.png", "content_b64": big}]})
+    assert resp.status_code == 413
+    assert "big.png is 11 bytes" in resp.json()["detail"]
+    save.assert_not_called()  # one bad file rejects the whole batch, before any write
+    preview.assert_not_called()
+
+
+def test_push_at_cap_is_accepted(client, bearer, existing_store, monkeypatch):
+    monkeypatch.setenv("MCP_MAX_FILE_BYTES", "10")
+    content = base64.b64encode(b"y" * 10).decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "ok.css", "content_b64": content}]})
+    assert resp.status_code == 200
+
+
+def test_push_blank_tuning_env_vars_fall_back_to_defaults(client, bearer, existing_store, monkeypatch):
+    # sample.env-style blank values (VAR=) must count as unset, not crash int("").
+    monkeypatch.setenv("MCP_MAX_FILE_BYTES", "")
+    content = base64.b64encode(b"x").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "a.css", "content_b64": content}]})
+    assert resp.status_code == 200
+
+
+def test_push_empty_file_list_is_400(client, bearer, existing_store):
+    # batch_write rejects an empty batch; fail fast instead of a 500 mid-gather.
+    resp = client.post("/mcp/push", headers=bearer, json={"files": []})
+    assert resp.status_code == 400
+
+
+def test_push_overlays_live_session_state(client, bearer, existing_store, mocker):
+    # A live chat session's in-memory filestore must receive the pushed files,
+    # otherwise the next coder run would persist stale content over the push.
+    live_store = InMemoryFileStore()
+    live_store.write_bytes("index.html", b"<old>")
+    live_store.write_bytes("styles.css", b"body{}")
+    mocker.patch("breba_app.mcp_api.router.state_exists", return_value=True)
+    state = mocker.Mock(filestore=live_store)
+    mocker.patch("breba_app.mcp_api.router.load_state", return_value=state)
+
+    new_html = base64.b64encode(b"<new>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": new_html}]})
+    assert resp.status_code == 200
+    assert live_store.read_bytes("index.html") == b"<new>"
+    assert live_store.read_bytes("styles.css") == b"body{}"
+
+
+def test_push_without_live_session_skips_overlay(client, bearer, existing_store, mocker):
+    mocker.patch("breba_app.mcp_api.router.state_exists", return_value=False)
+    load_state = mocker.patch("breba_app.mcp_api.router.load_state")
+    new_html = base64.b64encode(b"<new>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": new_html}]})
+    assert resp.status_code == 200
+    load_state.assert_not_called()
+
+
+def test_push_threads_content_type_into_the_saved_files(client, bearer, existing_store):
+    # An explicit type must reach batch_write, or extensionless text files
+    # (CNAME, LICENSE) get stamped application/octet-stream in the manifest and
+    # the MCP read tools permanently refuse them as binary. Files pushed without
+    # one must arrive as None so batch_write guesses from the extension.
+    _, save = existing_store
+    cname = base64.b64encode(b"breba.example.com").decode()
+    html = base64.b64encode(b"<h1>hi</h1>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "CNAME", "content_b64": cname,
+                                        "content_type": "text/plain"},
+                                       {"path": "index.html", "content_b64": html}]})
+    assert resp.status_code == 200
+    saved = save.call_args.args[2]
+    assert [(fw.path, fw.content_type) for fw in saved] == [
+        ("CNAME", "text/plain"), ("index.html", None)]
+
+
+def test_push_save_failure_skips_preview_build(client, bearer, existing_store, mocker):
+    # The preview build publishes to the public bucket; if nothing was durably
+    # versioned, nothing may reach it (mirrors POST /upload's save-then-preview
+    # ordering — a build started before/alongside the save would trip this too).
+    mocker.patch("breba_app.mcp_api.router.save_files",
+                 mocker.AsyncMock(side_effect=RuntimeError("R2 write failed")))
+    preview = mocker.patch("breba_app.mcp_api.router.build_preview_incremental",
+                           mocker.AsyncMock())
+    content = base64.b64encode(b"x").decode()
+    with pytest.raises(RuntimeError, match="R2 write failed"):
+        client.post("/mcp/push", headers=bearer,
+                    json={"files": [{"path": "a.css", "content_b64": content}]})
+    preview.assert_not_called()
+
+
+def test_push_preview_failure_reports_the_saved_version(client, bearer, existing_store, mocker):
+    # The push persisted even though the preview build blew up (e.g. a broken
+    # Jinja template): the error must say so, so the client doesn't re-push the
+    # same files and stack identical broken versions.
+    _, save = existing_store
+    mocker.patch("breba_app.mcp_api.router.build_preview_incremental",
+                 mocker.AsyncMock(side_effect=RuntimeError("unexpected end of template")))
+    content = base64.b64encode(b"<new>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": content}]})
+    assert resp.status_code == 500
+    detail = resp.json()["detail"]
+    assert "saved as version 7" in detail
+    assert "unexpected end of template" in detail
+    assert save.await_count == 1
+
+
+def test_push_preview_failure_still_overlays_live_session(client, bearer, existing_store, mocker):
+    # The files are durably saved, so a stale open chat session must be updated
+    # even when the preview build fails — otherwise its next persist would
+    # silently revert the push.
+    mocker.patch("breba_app.mcp_api.router.build_preview_incremental",
+                 mocker.AsyncMock(side_effect=RuntimeError("boom")))
+    live_store = InMemoryFileStore()
+    live_store.write_bytes("index.html", b"<old>")
+    mocker.patch("breba_app.mcp_api.router.state_exists", return_value=True)
+    mocker.patch("breba_app.mcp_api.router.load_state",
+                 return_value=mocker.Mock(filestore=live_store))
+    content = base64.b64encode(b"<new>").decode()
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": content}]})
+    assert resp.status_code == 500
+    assert live_store.read_bytes("index.html") == b"<new>"
+
+
+def test_push_to_missing_product_is_404(client, bearer, mocker):
+    product = mocker.patch("breba_app.mcp_api.router.Product")
+    product.find_one = mocker.AsyncMock(return_value=None)  # product missing
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": "Zm9v"}]})
+    assert resp.status_code == 404
+
+
+def test_push_invalid_base64_is_400(client, bearer, existing_store):
+    resp = client.post("/mcp/push", headers=bearer,
+                       json={"files": [{"path": "index.html", "content_b64": "!!!not-base64!!!"}]})
+    assert resp.status_code == 400
+
+
+# --- /mcp/file/stat: metadata without a download -------------------------------
+
+def test_file_stat_returns_manifest_metadata(client, bearer, mocker):
+    stat = mocker.patch(
+        "breba_app.mcp_api.store.stat_file",
+        mocker.AsyncMock(return_value={"size": 12345, "content_type": "image/png"}))
+    resp = client.get("/mcp/file/stat", params={"path": "logo.png", "version": 5}, headers=bearer)
+    assert resp.status_code == 200
+    assert resp.json() == {"path": "logo.png", "size": 12345, "content_type": "image/png"}
+    stat.assert_awaited_once_with(USER_ID, PRODUCT_ID, "logo.png", 5)
+
+
+def test_file_stat_missing_file_is_404(client, bearer, mocker):
+    mocker.patch("breba_app.mcp_api.store.stat_file",
+                 mocker.AsyncMock(side_effect=NotFound("nope.png not found in version 3")))
+    resp = client.get("/mcp/file/stat", params={"path": "nope.png"}, headers=bearer)
+    assert resp.status_code == 404
+    assert "nope.png" in resp.json()["detail"]
+
+
+def test_file_stat_invalid_path_is_400(client, bearer):
+    resp = client.get("/mcp/file/stat", params={"path": "../evil"}, headers=bearer)
+    assert resp.status_code == 400
+
+
+# --- store.stat_file: version resolution ---------------------------------------
+
+def _stat_fs(mocker, active_version):
+    fs = mocker.Mock()
+    fs.get_version.return_value = active_version
+    fs._prefix = "u1/p1"
+    fs._bucket = "users"
+    mocker.patch("breba_app.mcp_api.store._filesystem", return_value=fs)
+    return fs
+
+
+def test_stat_file_reads_manifest_for_versioned_products(mocker):
+    fs = _stat_fs(mocker, active_version=3)
+    fs._get_manifest.return_value = {"files": {
+        "styles.css": {"key": "k", "size": 6, "content_type": "text/css"},
+    }}
+    meta = asyncio.run(store_module.stat_file("u1", "p1", "styles.css"))
+    assert meta == {"size": 6, "content_type": "text/css"}
+    fs._get_manifest.assert_called_once_with(3)
+
+
+def test_stat_file_version_0_heads_the_unversioned_object(mocker):
+    # Legacy pre-versioning products: read_file's version-0 branch serves the
+    # unversioned object directly, so stat must resolve the same way instead of
+    # 404ing on the placeholder v0 manifest.
+    fs = _stat_fs(mocker, active_version=0)
+    fs._s3.head_object.return_value = {"ContentLength": 42, "ContentType": "text/css"}
+    meta = asyncio.run(store_module.stat_file("u1", "p1", "styles.css"))
+    assert meta == {"size": 42, "content_type": "text/css"}
+    fs._s3.head_object.assert_called_once_with(Bucket="users", Key="u1/p1/styles.css")
+    fs._get_manifest.assert_not_called()
+
+
+def test_stat_file_version_0_missing_object_is_not_found(mocker):
+    from botocore.exceptions import ClientError
+
+    fs = _stat_fs(mocker, active_version=0)
+    fs._s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+    with pytest.raises(NotFound, match="version 0"):
+        asyncio.run(store_module.stat_file("u1", "p1", "nope.css"))
+
+
+def test_stat_file_missing_from_versioned_manifest_is_not_found(mocker):
+    fs = _stat_fs(mocker, active_version=3)
+    fs._get_manifest.return_value = {"files": {}}
+    with pytest.raises(NotFound, match="nope.css not found in version 3"):
+        asyncio.run(store_module.stat_file("u1", "p1", "nope.css"))
+
+
+# --- store.list_files / store.read_file: single version resolution -------------
+# The router tests fake these helpers, so their real version-resolution contract
+# — "resolve None to the active version exactly once, and report that version
+# back" — is pinned here, against the filesystem boundary.
+
+def _read_fs(mocker, active_version):
+    fs = mocker.Mock()
+    fs.get_version.return_value = active_version
+    fs.read_file = mocker.AsyncMock()
+    mocker.patch("breba_app.mcp_api.store._filesystem", return_value=fs)
+    return fs
+
+
+def test_store_list_files_resolves_the_active_version_once(mocker):
+    fs = _read_fs(mocker, active_version=3)
+    fs.list_files.return_value = ["a.html", "b.css"]
+
+    assert asyncio.run(store_module.list_files("u1", "p1")) == (["a.html", "b.css"], 3)
+
+    # The listed manifest is exactly the resolved version reported back.
+    fs.list_files.assert_called_once_with(3)
+    fs.get_version.assert_called_once_with()
+
+
+def test_store_list_files_passes_an_explicit_version_through(mocker):
+    fs = _read_fs(mocker, active_version=3)
+    fs.list_files.return_value = ["a.html"]
+
+    assert asyncio.run(store_module.list_files("u1", "p1", version=5)) == (["a.html"], 5)
+
+    fs.list_files.assert_called_once_with(5)
+    fs.get_version.assert_not_called()
+
+
+def test_store_read_file_resolves_the_active_version_once(mocker):
+    fs = _read_fs(mocker, active_version=3)
+    fw = FileWrite(path="a.html", content=b"<a>")
+    fs.read_file.return_value = fw
+
+    assert asyncio.run(store_module.read_file("u1", "p1", "a.html")) == (fw, 3)
+
+    fs.read_file.assert_awaited_once_with("a.html", version=3)
+
+
+def test_store_read_file_passes_an_explicit_version_through(mocker):
+    fs = _read_fs(mocker, active_version=3)
+    fw = FileWrite(path="a.html", content=b"<v5>")
+    fs.read_file.return_value = fw
+
+    assert asyncio.run(store_module.read_file("u1", "p1", "a.html", version=5)) == (fw, 5)
+
+    fs.read_file.assert_awaited_once_with("a.html", version=5)
+    fs.get_version.assert_not_called()
+
+
+def test_store_read_file_propagates_not_found(mocker):
+    fs = _read_fs(mocker, active_version=3)
+    fs.read_file.side_effect = NotFound("a.html not found in version 3")
+    with pytest.raises(NotFound, match="a.html not found"):
+        asyncio.run(store_module.read_file("u1", "p1", "a.html"))
+
+
+# --- store.read_all_files: bulk read for the push path ------------------------
+
+def test_read_all_files_resolves_manifest_once_and_reads_by_key(mocker):
+    fs = mocker.Mock()
+    fs.get_version.return_value = 3
+    fs._get_manifest.return_value = {"files": {
+        "index.html": {"key": "u1/p1/versions/3/index.html"},
+        "styles.css": {"key": "u1/p1/versions/2/styles.css"},  # carried forward from v2
+    }}
+    mocker.patch("breba_app.mcp_api.store._filesystem", return_value=fs)
+    mocker.patch("breba_app.mcp_api.store.Settings", SimpleNamespace(USERS_BUCKET="users"))
+    s3 = mocker.Mock()
+    s3.get_object.side_effect = lambda Bucket, Key: {
+        "Body": SimpleNamespace(read=lambda: f"<{Key}>".encode()),
+        "ContentType": "text/html",
+    }
+    mocker.patch("breba_app.mcp_api.store.get_s3_client", return_value=s3)
+
+    result = asyncio.run(store_module.read_all_files("u1", "p1"))
+
+    # Each file is fetched by its manifest key (which may point at an older
+    # version's object), after a single version+manifest resolution.
+    assert result.read_bytes("index.html") == b"<u1/p1/versions/3/index.html>"
+    assert result.read_bytes("styles.css") == b"<u1/p1/versions/2/styles.css>"
+    fs._get_manifest.assert_called_once_with(3)
+    assert all(kw["Bucket"] == "users" for _, kw in s3.get_object.call_args_list)
+
+
+# --- preview.build_preview_incremental: skip unchanged uploads ----------------
+
+def _run_incremental_preview(mocker, files: dict[str, bytes], existing_etags: dict[str, str]):
+    from breba_app.mcp_api import preview as preview_module
+
+    store = InMemoryFileStore()
+    for path, content in files.items():
+        store.write_bytes(path, content)
+    # The Jinja build step is exercised by the builder's own tests; identity here.
+    mocker.patch("breba_app.mcp_api.preview.build", side_effect=lambda fs: fs)
+    mocker.patch("breba_app.mcp_api.preview._list_preview_etags",
+                 return_value=existing_etags)
+    bucket = mocker.Mock()
+    asyncio.run(preview_module.build_preview_incremental(PRODUCT_ID, store, bucket=bucket))
+    return bucket
+
+
+def test_incremental_preview_skips_byte_identical_files(mocker):
+    import hashlib
+
+    css = b"body{}"
+    bucket = _run_incremental_preview(
+        mocker,
+        files={"index.html": b"<p>hi</p>", "styles.css": css},
+        existing_etags={f"{PRODUCT_ID}/styles.css": hashlib.md5(css).hexdigest()},
+    )
+    uploaded = [kw["Key"] for _, kw in bucket.put_object.call_args_list]
+    assert uploaded == [f"{PRODUCT_ID}/index.html"]  # unchanged css not re-uploaded
+
+
+def test_incremental_preview_reuploads_changed_and_unlisted_files(mocker):
+    import hashlib
+
+    bucket = _run_incremental_preview(
+        mocker,
+        files={"styles.css": b"body{color:red}", "logo.svg": b"<svg/>"},
+        existing_etags={f"{PRODUCT_ID}/styles.css": hashlib.md5(b"body{}").hexdigest()},
+    )
+    uploaded = sorted(kw["Key"] for _, kw in bucket.put_object.call_args_list)
+    assert uploaded == [f"{PRODUCT_ID}/logo.svg", f"{PRODUCT_ID}/styles.css"]
+
+
+def test_incremental_preview_render_failure_names_files_and_uploads_the_rest(mocker):
+    # This raised RuntimeError is what the router turns into its "saved as
+    # version N, don't re-push" 500 — the router tests fake the raise, so the
+    # real collect-failures-then-raise behavior is pinned here. The healthy
+    # files must still reach the bucket first (mirrors build_preview's
+    # per-file skip), so one corrupt asset doesn't hold back the whole preview.
+    from breba_app.mcp_api import preview as preview_module
+
+    class FlakyStore(InMemoryFileStore):
+        def read_bytes(self, path):
+            if path == "bad.bin":
+                raise IOError("corrupt object")
+            return super().read_bytes(path)
+
+    store = FlakyStore()
+    store.write_bytes("index.html", b"<p>hi</p>")
+    store.write_bytes("bad.bin", b"\x00")
+    mocker.patch("breba_app.mcp_api.preview.build", side_effect=lambda fs: fs)
+    mocker.patch("breba_app.mcp_api.preview._list_preview_etags", return_value={})
+    bucket = mocker.Mock()
+
+    with pytest.raises(RuntimeError, match="bad.bin"):
+        asyncio.run(preview_module.build_preview_incremental(PRODUCT_ID, store, bucket=bucket))
+
+    uploaded = [kw["Key"] for _, kw in bucket.put_object.call_args_list]
+    assert f"{PRODUCT_ID}/index.html" in uploaded
+
+
+def _etag_pages(mocker, pages):
+    s3 = mocker.Mock()
+    s3.get_paginator.return_value.paginate.return_value = pages
+    mocker.patch("breba_app.mcp_api.preview.get_s3_client", return_value=s3)
+    return s3
+
+
+def test_list_preview_etags_lists_the_given_bucket(mocker):
+    # The skip decisions must be made against the bucket the writes go to.
+    from breba_app.mcp_api import preview as preview_module
+
+    s3 = _etag_pages(mocker, [{"Contents": [{"Key": "prod-1/a.css", "ETag": '"abc"'}]}])
+    bucket = mocker.Mock()
+    bucket.name = "custom-bucket"
+
+    etags = preview_module._list_preview_etags(PRODUCT_ID, bucket)
+
+    assert etags == {"prod-1/a.css": "abc"}
+    s3.get_paginator.return_value.paginate.assert_called_once_with(
+        Bucket="custom-bucket", Prefix=f"{PRODUCT_ID}/")
+
+
+def test_list_preview_etags_defaults_to_the_public_bucket(mocker):
+    from breba_app.mcp_api import preview as preview_module
+
+    s3 = _etag_pages(mocker, [{}])  # page without Contents (empty prefix)
+    mocker.patch("breba_app.mcp_api.preview.Settings",
+                 SimpleNamespace(PUBLIC_BUCKET="public"))
+
+    assert preview_module._list_preview_etags(PRODUCT_ID) == {}
+    s3.get_paginator.return_value.paginate.assert_called_once_with(
+        Bucket="public", Prefix=f"{PRODUCT_ID}/")
+
+
+# --- /mcp/products: list the token owner's products ---------------------------
+
+def test_list_products_returns_owned_products_and_current(client, mocker):
+    user_oid = "a1b2c3d4e5f6a7b8c9d0e1f2"  # /mcp/products parses user_id as an ObjectId
+    headers = {"Authorization": f"Bearer {auth.mint_token(user_oid, PRODUCT_ID)[0]}"}
+    owned = [SimpleNamespace(product_id="prod-1", name="Boat Site"),
+             SimpleNamespace(product_id="prod-2", name=None)]  # unnamed -> id as name
+    product = mocker.patch("breba_app.mcp_api.products.Product")
+    query = mocker.Mock()
+    query.to_list = mocker.AsyncMock(return_value=owned)
+    product.find.return_value = query
+
+    resp = client.get("/mcp/products", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "products": [{"id": "prod-1", "name": "Boat Site"},
+                     {"id": "prod-2", "name": "prod-2"}],
+        "current": PRODUCT_ID,
+    }
+
+
+def test_list_products_requires_token(client):
+    assert client.get("/mcp/products").status_code == 401

--- a/tests/test_mcp_authorize.py
+++ b/tests/test_mcp_authorize.py
@@ -74,7 +74,9 @@ def app():
 
 @pytest.fixture
 def client(app):
-    return TestClient(app, follow_redirects=False)
+    # Default Origin matches TestClient's base URL, as a real browser would send.
+    return TestClient(app, follow_redirects=False,
+                      headers={"origin": "http://testserver"})
 
 
 def _login_as(app, identifier="alice"):
@@ -343,6 +345,35 @@ def test_deny_redirects_with_access_denied(app, client, mocker):
     qs = parse_qs(urlparse(resp.headers["location"]).query)
     assert qs["error"] == ["access_denied"]
     assert qs["state"] == ["xyz"]
+
+
+def _post_approve(client, **headers):
+    return client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+    }, headers=headers)
+
+
+@pytest.mark.parametrize("headers", [
+    {"origin": "http://evil.example.com"},
+    {"origin": "", "referer": ""},  # neither header: fail closed
+])
+def test_approve_cross_or_missing_origin_redirects_with_error(app, client, mocker, headers):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()])
+    resp = _post_approve(client, **headers)
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["invalid_origin"]
+    assert qs["state"] == ["xyz"]
+
+
+def test_approve_accepts_matching_referer_without_origin(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()])
+    resp = _post_approve(client, origin="", referer="http://testserver/mcp/authorize")
+    assert resp.status_code == 303
+    assert "code" in parse_qs(urlparse(resp.headers["location"]).query)
 
 
 def test_approve_unowned_product_redirects_with_error(app, client, mocker):

--- a/tests/test_mcp_authorize.py
+++ b/tests/test_mcp_authorize.py
@@ -1,0 +1,437 @@
+import asyncio
+import time
+from html.parser import HTMLParser
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from breba_app.mcp_api import auth
+from breba_app.mcp_api import authorize
+from breba_app.mcp_api.authorize import optional_current_user, router
+from breba_app.paths import templates
+
+SECRET = "test-secret"
+USER_ID = "uid-123"
+PRODUCT_ID = "prod-1"
+
+
+class _Page(HTMLParser):
+    """Minimal structural view of a rendered page.
+
+    Assert against parsed form inputs / anchor hrefs / option values instead of
+    raw markup so a cosmetic template edit (class names, attribute order,
+    whitespace) doesn't break the test while the behavior it guards is intact.
+    """
+
+    def __init__(self, html_text: str):
+        super().__init__()
+        self.inputs: dict[str, str] = {}   # input name -> value
+        self.anchors: list[dict[str, str]] = []  # <a> attribute dicts
+        self.options: list[str] = []       # <option> values
+        self.feed(html_text)
+
+    def handle_starttag(self, tag, attrs):
+        d = dict(attrs)
+        if tag == "input" and "name" in d:
+            self.inputs[d["name"]] = d.get("value", "")
+        elif tag == "a":
+            self.anchors.append(d)
+        elif tag == "option":
+            self.options.append(d.get("value", ""))
+
+    def anchor(self, **match) -> dict[str, str]:
+        return next(a for a in self.anchors
+                   if all(a.get(k) == v for k, v in match.items()))
+
+
+@pytest.fixture(autouse=True)
+def _secret(monkeypatch):
+    monkeypatch.setenv("CHAINLIT_AUTH_SECRET", SECRET)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_consumed_codes():
+    # The consumed-nonce registry is module-level state; clear it so test order
+    # doesn't matter.
+    auth.reset_consumed_codes()
+
+
+@pytest.fixture(autouse=True)
+def _asset_global():
+    # base.html uses {{ asset(...) }}; main.py sets this at import — stub it for tests.
+    templates.env.globals.setdefault("asset", lambda name: f"/public/{name}")
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, follow_redirects=False)
+
+
+def _login_as(app, identifier="alice"):
+    app.dependency_overrides[optional_current_user] = lambda: SimpleNamespace(identifier=identifier)
+
+
+def _patch_db(mocker, products, find_one_product=None):
+    db_user = SimpleNamespace(id=USER_ID, username="alice")
+    user = mocker.patch("breba_app.mcp_api.authorize.User")
+    user.find_one = mocker.AsyncMock(return_value=db_user)
+    product = mocker.patch("breba_app.mcp_api.products.Product")
+    query = mocker.MagicMock()
+    query.to_list = mocker.AsyncMock(return_value=products)
+    product.find.return_value = query
+    product.find_one = mocker.AsyncMock(return_value=find_one_product)
+    return user, product
+
+
+def _make_product(product_id=PRODUCT_ID, name="BoatFix Pro"):
+    return SimpleNamespace(product_id=product_id, name=name)
+
+
+# --- loopback validation -----------------------------------------------------
+
+@pytest.mark.parametrize("uri,ok", [
+    ("http://127.0.0.1:54321/callback", True),
+    ("http://localhost:8765/callback", True),
+    ("https://localhost:8765/callback", True),
+    ("http://evil.example.com/callback", False),
+    ("ftp://127.0.0.1/callback", False),
+    ("not-a-url", False),
+])
+def test_is_loopback(uri, ok):
+    assert authorize._is_loopback(uri) is ok
+
+
+# --- optional_current_user: resolve the Chainlit session, or None -------------
+# Every other test overrides this dependency, so its real body — including the
+# swallow-HTTPException-to-None path a bad cookie relies on — is pinned here.
+
+def test_optional_current_user_returns_none_without_a_session_token(mocker):
+    authenticate = mocker.patch("breba_app.mcp_api.authorize.authenticate_user")
+    assert asyncio.run(optional_current_user(None)) is None
+    authenticate.assert_not_called()
+
+
+def test_optional_current_user_resolves_a_valid_session(mocker):
+    user = SimpleNamespace(identifier="alice")
+    mocker.patch("breba_app.mcp_api.authorize.authenticate_user",
+                 mocker.AsyncMock(return_value=user))
+    assert asyncio.run(optional_current_user("good-token")) is user
+
+
+def test_optional_current_user_swallows_a_rejected_session(mocker):
+    # A bad/expired cookie must yield None so the flow renders the sign-in page,
+    # not raise and turn the authorize request into a 500.
+    mocker.patch("breba_app.mcp_api.authorize.authenticate_user",
+                 mocker.AsyncMock(side_effect=HTTPException(status_code=401)))
+    assert asyncio.run(optional_current_user("stale-token")) is None
+
+
+# --- POST /mcp/token : code -> bearer token ----------------------------------
+
+def test_token_exchange_returns_valid_bearer(client):
+    code = auth.mint_code(USER_ID, PRODUCT_ID)
+    resp = client.post("/mcp/token", json={"code": code})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["product_id"] == PRODUCT_ID
+    assert body["expires_at"] > time.time()
+    data = auth.verify_token(body["token"])
+    assert data["user_id"] == USER_ID
+    assert data["product_id"] == PRODUCT_ID
+
+
+def test_token_exchange_rejects_invalid_code(client):
+    resp = client.post("/mcp/token", json={"code": "garbage"})
+    assert resp.status_code == 400
+
+
+def test_token_exchange_rejects_expired_code(client):
+    resp = client.post("/mcp/token", json={"code": auth.mint_code(USER_ID, PRODUCT_ID, ttl=-10)})
+    assert resp.status_code == 400
+
+
+def test_token_exchange_rejects_a_bearer_token_as_code(client):
+    # A long-lived bearer token must not be accepted at the code-exchange endpoint.
+    resp = client.post("/mcp/token", json={"code": auth.mint_token(USER_ID, PRODUCT_ID)[0]})
+    assert resp.status_code == 400
+
+
+def test_token_exchange_is_single_use(client):
+    # A leaked code must not mint a second bearer within its TTL.
+    code = auth.mint_code(USER_ID, PRODUCT_ID)
+    assert client.post("/mcp/token", json={"code": code}).status_code == 200
+    assert client.post("/mcp/token", json={"code": code}).status_code == 400
+
+
+# --- PKCE (RFC 7636, S256) -----------------------------------------------------
+
+VERIFIER = "correct-horse-battery-staple"
+
+
+def _pkce_code():
+    return auth.mint_code(USER_ID, PRODUCT_ID,
+                          code_challenge=auth.make_code_challenge(VERIFIER))
+
+
+def test_token_exchange_accepts_matching_verifier(client):
+    resp = client.post("/mcp/token", json={"code": _pkce_code(), "code_verifier": VERIFIER})
+    assert resp.status_code == 200
+    assert auth.verify_token(resp.json()["token"])["user_id"] == USER_ID
+
+
+def test_token_exchange_rejects_wrong_verifier(client):
+    resp = client.post("/mcp/token", json={"code": _pkce_code(), "code_verifier": "wrong"})
+    assert resp.status_code == 400
+    assert "code_verifier" in resp.json()["detail"]
+
+
+def test_token_exchange_rejects_missing_verifier_when_code_has_challenge(client):
+    assert client.post("/mcp/token", json={"code": _pkce_code()}).status_code == 400
+
+
+def test_failed_pkce_attempt_burns_the_code(client):
+    # The code is consumed before the verifier check, so an attacker who
+    # intercepted it can't probe verifiers: one wrong guess invalidates it.
+    code = _pkce_code()
+    assert client.post("/mcp/token", json={"code": code, "code_verifier": "wrong"}).status_code == 400
+    assert client.post("/mcp/token", json={"code": code, "code_verifier": VERIFIER}).status_code == 400
+
+
+def test_code_without_challenge_needs_no_verifier(client):
+    # PKCE is client-initiated defense in depth; codes minted without a
+    # challenge still exchange (loopback + single-use remain in force).
+    code = auth.mint_code(USER_ID, PRODUCT_ID)
+    assert client.post("/mcp/token", json={"code": code}).status_code == 200
+
+
+# --- verify_code purity vs consume_code one-shot ------------------------------
+
+def test_verify_code_stays_pure_and_consume_code_is_one_shot():
+    code = auth.mint_code(USER_ID, PRODUCT_ID)
+    assert auth.verify_code(code) is not None
+    assert auth.verify_code(code) is not None  # no side effects
+    assert auth.consume_code(code) is not None
+    assert auth.consume_code(code) is None
+    assert auth.verify_code(code) is not None  # still pure after consumption
+
+
+# --- GET /mcp/authorize : consent page ---------------------------------------
+
+def test_authorize_signin_page_preserves_the_authorize_url(app, client):
+    # The query is the one-time authorize request the waiting MCP server minted,
+    # and /login has no return-redirect — a plain login link would orphan the
+    # flow at "/" until the loopback wait times out. The page must open sign-in
+    # in a new tab and offer a continue link that re-hits this very URL.
+    app.dependency_overrides[optional_current_user] = lambda: None
+    params = {"redirect_uri": "http://127.0.0.1:54321/callback",
+              "state": "xyz", "product_id": PRODUCT_ID, "code_challenge": "chall-abc"}
+    resp = client.get("/mcp/authorize", params=params)
+    assert resp.status_code == 401
+    page = _Page(resp.text)
+
+    # Sign-in opens in a new tab so it doesn't navigate this page away.
+    assert page.anchor(href="/login")["target"] == "_blank"
+
+    # The continue link re-hits this authorize URL, carrying the whole one-time
+    # request so the flow isn't orphaned after login.
+    cont = next(a for a in page.anchors if a["href"].startswith("/mcp/authorize?"))
+    assert parse_qs(urlparse(cont["href"]).query) == {k: [v] for k, v in params.items()}
+
+
+def test_authorize_rejects_non_loopback_redirect(app, client):
+    _login_as(app)
+    resp = client.get("/mcp/authorize",
+                      params={"redirect_uri": "http://evil.example.com/callback"})
+    assert resp.status_code == 400
+    assert "loopback" in resp.text
+
+
+def test_authorize_renders_consent_with_product(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()])
+    resp = client.get("/mcp/authorize", params={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "code_challenge": "chall-abc",
+    })
+    assert resp.status_code == 200
+    page = _Page(resp.text)
+    assert "Authorize coding agent" in resp.text  # consent heading
+    assert "BoatFix Pro" in resp.text             # product name rendered
+    assert page.inputs["state"] == "xyz"          # state carried into the form
+    assert page.inputs["code_challenge"] == "chall-abc"  # PKCE challenge too
+    assert PRODUCT_ID in page.options             # owned product offered
+
+
+def test_approve_embeds_code_challenge_in_the_code(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()], find_one_product=_make_product())
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+        "code_challenge": "chall-abc",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert auth.verify_code(qs["code"][0])["code_challenge"] == "chall-abc"
+
+
+def test_authorize_unknown_product_redirects_with_error(app, client, mocker):
+    # An error page here would never redirect to the loopback callback and the
+    # local MCP server would hang — the error must go back via the redirect.
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()])
+    resp = client.get("/mcp/authorize", params={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": "not-mine",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["invalid_product"]
+    assert "not-mine" in qs["error_description"][0]
+    assert qs["state"] == ["xyz"]
+
+
+def test_authorize_no_products_redirects_with_error(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[])
+    resp = client.get("/mcp/authorize", params={
+        "redirect_uri": "http://127.0.0.1:54321/callback", "state": "xyz",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["no_products"]
+    assert qs["state"] == ["xyz"]
+
+
+# --- POST /mcp/authorize : consent decision ----------------------------------
+
+def test_approve_redirects_to_loopback_with_valid_code(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()], find_one_product=_make_product())
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+    })
+    assert resp.status_code == 303
+    location = resp.headers["location"]
+    assert location.startswith("http://127.0.0.1:54321/callback?")
+    qs = parse_qs(urlparse(location).query)
+    assert qs["state"] == ["xyz"]
+    data = auth.verify_code(qs["code"][0])
+    assert data["user_id"] == USER_ID
+    assert data["product_id"] == PRODUCT_ID
+
+
+def test_deny_redirects_with_access_denied(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()])
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "deny",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["access_denied"]
+    assert qs["state"] == ["xyz"]
+
+
+def test_approve_unowned_product_redirects_with_error(app, client, mocker):
+    _login_as(app)
+    _patch_db(mocker, products=[_make_product()], find_one_product=None)
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": "not-mine", "decision": "approve",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["invalid_product"]
+    assert qs["state"] == ["xyz"]
+
+
+def test_approve_expired_session_redirects_with_error(app, client):
+    app.dependency_overrides[optional_current_user] = lambda: None
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["session_expired"]
+    assert qs["state"] == ["xyz"]
+
+
+def test_approve_non_loopback_redirect_is_400(app, client):
+    _login_as(app)
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://evil.example.com/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+    })
+    assert resp.status_code == 400
+
+
+# --- unlocatable account: Chainlit identity with no DB user --------------------
+
+def _login_without_db_user(app, mocker):
+    """Signed in via Chainlit, but no matching User document exists."""
+    _login_as(app)
+    user = mocker.patch("breba_app.mcp_api.authorize.User")
+    user.find_one = mocker.AsyncMock(return_value=None)
+
+
+def test_authorize_unlocatable_account_redirects_with_error(app, client, mocker):
+    # Like every other terminal error, this must go back via the loopback
+    # redirect — an error page would strand the waiting MCP server.
+    _login_without_db_user(app, mocker)
+    resp = client.get("/mcp/authorize", params={
+        "redirect_uri": "http://127.0.0.1:54321/callback", "state": "xyz",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["account_not_found"]
+    assert qs["state"] == ["xyz"]
+
+
+def test_approve_unlocatable_account_redirects_with_error(app, client, mocker):
+    _login_without_db_user(app, mocker)
+    resp = client.post("/mcp/authorize", data={
+        "redirect_uri": "http://127.0.0.1:54321/callback",
+        "state": "xyz", "product_id": PRODUCT_ID, "decision": "approve",
+    })
+    assert resp.status_code == 303
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["account_not_found"]
+    assert qs["state"] == ["xyz"]
+
+
+# --- consume_code under concurrency ---------------------------------------------
+
+def test_concurrent_exchanges_of_one_code_have_a_single_winner():
+    # The check-and-record runs under a lock: two exchanges of the same leaked
+    # code racing each other must not both mint a bearer.
+    import threading
+
+    code = auth.mint_code(USER_ID, PRODUCT_ID)
+    barrier = threading.Barrier(8)
+    results = []
+
+    def attempt():
+        barrier.wait()
+        results.append(auth.consume_code(code))
+
+    threads = [threading.Thread(target=attempt) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(r is not None for r in results) == 1

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -1,0 +1,187 @@
+"""Contract tests: the real MCP tools and SiteClient against the real /mcp router.
+
+The unit suites for the two halves (tests/test_mcp_server.py, tests/test_mcp_api.py)
+each mock the other side of the HTTP seam, so neither can catch drift in the wire
+contract — field names, query params, the bearer header, status codes. A misspelled
+``expected_version`` key in SiteClient.push, for example, would pass every unit
+test while pydantic silently dropped the field and disabled the concurrency guard
+in production.
+
+Here the local server's real code path (tool -> SiteClient -> httpx request
+building) executes against the real FastAPI router (real ``require_push_token``,
+real endpoint signatures), with only the storage/DB boundary mocked. Starlette's
+``TestClient`` is itself an ``httpx.Client``, so patching the client's
+``httpx.Client`` constructor routes real HTTP semantics into the in-process app.
+Auth uses genuinely minted tokens via ``BREBA_MCP_TOKEN`` — no browser flow, and
+the real ``ensure_auth``/token-provider path still runs.
+"""
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from breba_app.filesystem.in_memory_store import InMemoryFileStore
+from breba_app.filesystem.models import FileWrite
+from breba_app.mcp_api import auth as api_auth
+from breba_app.mcp_api.router import router
+from mcp_server import server
+from mcp_server.client import SiteApiError, SiteClient
+
+USER_ID = "a1b2c3d4e5f6a7b8c9d0e1f2"  # /mcp/products parses user_id as an ObjectId
+PRODUCT_ID = "prod-1"
+BASE = "http://testserver"
+
+
+@pytest.fixture(autouse=True)
+def _env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHAINLIT_AUTH_SECRET", "contract-secret")
+    monkeypatch.setenv("BREBA_MCP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("BREBA_BASE_URL", BASE)
+    monkeypatch.delenv("BREBA_PRODUCT_ID", raising=False)
+    monkeypatch.delenv("BREBA_MCP_MAX_FILE_BYTES", raising=False)
+    monkeypatch.setattr(server, "_product_override", None)
+    monkeypatch.setattr(server, "_clients", {})
+    monkeypatch.setattr(server, "_observed_versions", {})
+
+
+@pytest.fixture
+def api(mocker):
+    """The real router on a real ASGI app; only the storage/DB boundary is mocked."""
+    store = InMemoryFileStore()
+    store.write_bytes("index.html", b"<old>")
+    product = mocker.patch("breba_app.mcp_api.router.Product")
+    product.find_one = mocker.AsyncMock(return_value=object())
+    mocks = SimpleNamespace(
+        stat=mocker.patch("breba_app.mcp_api.store.stat_file", mocker.AsyncMock(
+            return_value={"size": 5, "content_type": "text/html"})),
+        read=mocker.patch("breba_app.mcp_api.store.read_file", mocker.AsyncMock(
+            return_value=(FileWrite(path="index.html", content=b"<old>"), 6))),
+        list=mocker.patch("breba_app.mcp_api.store.list_files", mocker.AsyncMock(
+            return_value=(["index.html"], 6))),
+        read_all=mocker.patch("breba_app.mcp_api.store.read_all_files",
+                              mocker.AsyncMock(return_value=store)),
+        active=mocker.patch("breba_app.mcp_api.router.get_active_version",
+                            mocker.AsyncMock(return_value=6)),
+        save=mocker.patch("breba_app.mcp_api.router.save_files",
+                          mocker.AsyncMock(return_value=7)),
+        preview=mocker.patch("breba_app.mcp_api.router.build_preview_incremental",
+                             mocker.AsyncMock()),
+        index=mocker.patch("breba_app.mcp_api.router.get_index_html_path",
+                           return_value="http://prod-1.localhost:8088/index.html"),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return app, mocks
+
+
+def _route_wire_into(mocker, app):
+    """Make SiteClient's own httpx.Client dispatch into the in-process app."""
+    mocker.patch("mcp_server.client.httpx.Client", return_value=TestClient(app))
+
+
+@pytest.fixture
+def full_stack(api, mocker, monkeypatch):
+    """Real tool -> real SiteClient -> real router, authed by a real minted token."""
+    app, mocks = api
+    monkeypatch.setenv("BREBA_MCP_TOKEN", api_auth.mint_token(USER_ID, PRODUCT_ID)[0])
+    _route_wire_into(mocker, app)
+    return mocks
+
+
+# --- the optimistic-concurrency guard, end to end ------------------------------
+
+def test_stale_push_is_rejected_across_the_real_wire(full_stack):
+    # This is the test a client-side wire-format typo cannot survive: the
+    # observed revision must reach the router's preflight under the exact field
+    # name PushIn expects, or pydantic drops it and the push sails through.
+    server.read_site_file("index.html")   # observes active revision 6
+    full_stack.active.return_value = 7    # another edit landed since the read
+
+    with pytest.raises(SiteApiError) as err:
+        server.push_site([server.FileArg(path="index.html", content="<new>")])
+
+    assert err.value.status_code == 409
+    full_stack.save.assert_not_awaited()
+
+
+def test_push_with_current_version_lands(full_stack):
+    server.read_site_file("index.html")
+
+    result = server.push_site([server.FileArg(path="index.html", content="<new>")])
+
+    assert result == {"version": 7, "product_id": PRODUCT_ID}
+    saved = full_stack.save.await_args.args[2]
+    assert [(fw.path, fw.content) for fw in saved] == [("index.html", b"<new>")]
+
+
+def test_unguarded_push_skips_the_version_preflight(full_stack):
+    # No read happened: no expected_version may cross the wire, and the router
+    # must not spend a round-trip resolving a version nobody compares against.
+    result = server.push_site([server.FileArg(path="index.html", content="<new>")])
+
+    assert result["version"] == 7
+    full_stack.active.assert_not_awaited()
+
+
+# --- auth handshake -------------------------------------------------------------
+
+def test_expired_token_triggers_refresh_and_retry(api, mocker):
+    # The real require_push_token rejects a genuinely expired token with a 401;
+    # the real SiteClient must force-refresh and retry once, transparently.
+    app, _ = api
+    _route_wire_into(mocker, app)
+    expired = api_auth.mint_token(USER_ID, PRODUCT_ID, ttl=-10)[0]
+    fresh = api_auth.mint_token(USER_ID, PRODUCT_ID)[0]
+    seen = []
+
+    def provider(force_refresh=False):
+        seen.append(force_refresh)
+        return fresh if force_refresh else expired
+
+    out = SiteClient(BASE, provider).list_files()
+
+    assert out == {"files": ["index.html"], "version": 6}
+    assert seen == [False, True]
+
+
+# --- reads, params, and error mapping -------------------------------------------
+
+def test_versioned_read_params_survive_the_wire(full_stack):
+    full_stack.read.return_value = (FileWrite(path="index.html", content=b"<v5>"), 5)
+
+    out = server.read_site_file("index.html", version=5)
+
+    assert out == {"path": "index.html", "content": "<v5>"}
+    # The query-param names the client sends are the ones the endpoints declare.
+    full_stack.stat.assert_awaited_once_with(USER_ID, PRODUCT_ID, "index.html", 5)
+    full_stack.read.assert_awaited_once_with(USER_ID, PRODUCT_ID, "index.html", 5)
+
+
+def test_invalid_path_maps_to_400_across_the_wire(api, mocker):
+    # The store contract raises ValueError for a bad path; the router must map
+    # it to a 400 the client surfaces as a SiteApiError with that status.
+    app, mocks = api
+    _route_wire_into(mocker, app)
+    mocks.read.side_effect = ValueError("bad path")
+    client = SiteClient(BASE, lambda force=False: api_auth.mint_token(USER_ID, PRODUCT_ID)[0])
+
+    with pytest.raises(SiteApiError) as err:
+        client.read_file("../evil")
+
+    assert err.value.status_code == 400
+
+
+def test_products_and_preview_cross_the_wire(full_stack, mocker):
+    owned = [SimpleNamespace(product_id=PRODUCT_ID, name="Boat Site")]
+    product = mocker.patch("breba_app.mcp_api.products.Product")
+    query = mocker.Mock()
+    query.to_list = mocker.AsyncMock(return_value=owned)
+    product.find.return_value = query
+
+    assert server.list_products() == {
+        "products": [{"id": PRODUCT_ID, "name": "Boat Site"}],
+        "current": PRODUCT_ID,
+    }
+    assert server.get_preview_url() == {
+        "preview_url": "http://prod-1.localhost:8088/index.html"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,927 @@
+import base64
+import threading
+import time
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from breba_app.mcp_api.auth import make_code_challenge
+from mcp_server import auth, config, server
+from mcp_server import client as client_module
+from mcp_server.client import SiteClient
+
+BASE = "http://localhost:8080"
+PID = "prod-1"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(tmp_path, monkeypatch):
+    """Point the token cache at a temp dir and clear env overrides per test."""
+    monkeypatch.setenv("BREBA_MCP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("BREBA_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("BREBA_BASE_URL", raising=False)
+    monkeypatch.delenv("BREBA_PRODUCT_ID", raising=False)
+    monkeypatch.delenv("BREBA_MCP_MAX_FILE_BYTES", raising=False)
+    monkeypatch.setattr(server, "_product_override", None)
+    monkeypatch.setattr(server, "_clients", {})
+    monkeypatch.setattr(server, "_observed_versions", {})
+
+
+# --- token cache -------------------------------------------------------------
+
+def test_expired_cached_token_is_ignored():
+    auth.save_token(BASE, PID, "tok-old", expires_at=time.time() + 5)  # within skew
+    assert auth.load_cached_token(BASE, PID) is None
+
+
+def test_cache_is_keyed_by_base_and_product():
+    auth.save_token(BASE, PID, "tok-1", expires_at=time.time() + 3600)
+    assert auth.load_cached_token(BASE, "other-product") is None
+    assert auth.load_cached_token("http://other", PID) is None
+
+
+def test_save_token_preserves_other_entries():
+    auth.save_token(BASE, "prod-a", "tok-a", expires_at=time.time() + 3600)
+    auth.save_token(BASE, "prod-b", "tok-b", expires_at=time.time() + 3600)
+    assert auth.load_cached_token(BASE, "prod-a") == "tok-a"
+    assert auth.load_cached_token(BASE, "prod-b") == "tok-b"
+
+
+def test_token_cache_file_is_private_and_no_temp_left_behind():
+    import stat
+
+    auth.save_token(BASE, PID, "tok-abc", expires_at=time.time() + 3600)
+
+    path = config.token_file()
+    # Bearer tokens: owner read/write only, like other CLI credential files.
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    # The atomic-replace temp file must not linger next to the cache.
+    assert [p.name for p in path.parent.iterdir()] == [path.name]
+
+
+# --- token provider precedence ----------------------------------------------
+
+def test_provider_prefers_env_token(monkeypatch):
+    monkeypatch.setenv("BREBA_MCP_TOKEN", "env-token")
+    # Even with a cached token present, env wins and no browser flow runs.
+    auth.save_token(BASE, PID, "cached", expires_at=time.time() + 3600)
+    monkeypatch.setattr(auth, "obtain_token_via_browser",
+                        lambda *a: pytest.fail("should not open browser"))
+    provider = auth.make_token_provider(BASE, PID)
+    assert provider(False) == "env-token"
+    assert provider(True) == "env-token"
+
+
+def test_provider_uses_cache_then_browser(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        auth, "obtain_token_via_browser",
+        lambda base, pid: calls.append((base, pid)) or
+        {"token": "fresh-token", "product_id": pid, "expires_at": time.time() + 3600},
+    )
+    provider = auth.make_token_provider(BASE, PID)
+
+    # No cache yet -> browser flow.
+    assert provider(False) == "fresh-token"
+    assert calls == [(BASE, PID)]
+
+    # Now a valid cache exists -> no browser.
+    auth.save_token(BASE, PID, "cached-token", expires_at=time.time() + 3600)
+    assert provider(False) == "cached-token"
+    assert len(calls) == 1
+
+    # force_refresh bypasses the cache.
+    assert provider(True) == "fresh-token"
+    assert len(calls) == 2
+
+
+def test_provider_reports_picked_product_to_callback(monkeypatch):
+    # The consent page let the user approve prod-b although prod-a was
+    # requested: the provider must surface the pick so the caller retargets.
+    monkeypatch.setattr(
+        auth, "obtain_token_via_browser",
+        lambda base, pid: {"token": "tok-b", "product_id": "prod-b",
+                           "expires_at": time.time() + 3600},
+    )
+    picks = []
+    provider = auth.make_token_provider(BASE, "prod-a", on_product_change=picks.append)
+    assert provider(False) == "tok-b"
+    assert picks == ["prod-b"]
+
+
+def test_provider_skips_callback_when_pick_matches_request(monkeypatch):
+    monkeypatch.setattr(
+        auth, "obtain_token_via_browser",
+        lambda base, pid: {"token": "tok-a", "product_id": "prod-a",
+                           "expires_at": time.time() + 3600},
+    )
+    picks = []
+    provider = auth.make_token_provider(BASE, "prod-a", on_product_change=picks.append)
+    assert provider(False) == "tok-a"
+    assert picks == []
+
+
+# --- browser flow: never hangs -----------------------------------------------
+
+def test_browser_flow_times_out_instead_of_hanging(monkeypatch):
+    # If the browser never redirects back (e.g. server rendered an error page),
+    # the flow must give up with a clear error, not block the tool call forever.
+    monkeypatch.setattr(auth.webbrowser, "open", lambda url: True)
+    start = time.monotonic()
+    with pytest.raises(RuntimeError, match="timed out"):
+        auth.obtain_token_via_browser(BASE, PID, timeout=0.3)
+    assert time.monotonic() - start < 5
+
+
+def test_browser_flow_fails_fast_when_no_browser_opens(monkeypatch):
+    # On a browserless machine webbrowser.open returns False; the flow must
+    # raise immediately with guidance instead of waiting out the full timeout.
+    monkeypatch.setattr(auth.webbrowser, "open", lambda url: False)
+    start = time.monotonic()
+    with pytest.raises(RuntimeError, match="BREBA_MCP_TOKEN"):
+        auth.obtain_token_via_browser(BASE, PID, timeout=30)
+    assert time.monotonic() - start < 5
+
+
+def test_browser_flow_surfaces_error_redirect(monkeypatch):
+    # The server redirects errors (wrong product ID etc.) back to the loopback
+    # callback; the flow must raise them as a descriptive RuntimeError.
+    def fake_open(url):
+        q = parse_qs(urlparse(url).query)
+        redirect_uri, state = q["redirect_uri"][0], q["state"][0]
+
+        def hit_callback():
+            httpx.get(redirect_uri, params={
+                "error": "invalid_product",
+                "error_description": "Product 'nope' does not exist or is not yours.",
+                "state": state,
+            })
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(auth.webbrowser, "open", fake_open)
+    with pytest.raises(RuntimeError, match="invalid_product.*does not exist"):
+        auth.obtain_token_via_browser(BASE, PID, timeout=10)
+
+
+def test_browser_flow_ignores_stray_callback_probes(monkeypatch, mocker):
+    # A stray local GET (security software, extension probe) carrying neither
+    # code nor error must not end the wait: the flow keeps listening and the
+    # real redirect that follows still completes the authorization.
+    def fake_open(url):
+        q = parse_qs(urlparse(url).query)
+        redirect_uri, state = q["redirect_uri"][0], q["state"][0]
+
+        def probe_then_callback():
+            httpx.get(redirect_uri)  # no query params at all
+            httpx.get(redirect_uri.replace("/callback", "/favicon.ico"))
+            httpx.get(redirect_uri, params={"code": "c1", "state": state})
+
+        threading.Thread(target=probe_then_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(auth.webbrowser, "open", fake_open)
+    mocker.patch.object(auth.httpx, "post", return_value=_FakeResp(
+        200, {"token": "tok-1", "product_id": PID, "expires_at": time.time() + 3600},
+    ))
+
+    out = auth.obtain_token_via_browser(BASE, PID, timeout=10)
+    assert out["token"] == "tok-1"
+
+
+def test_browser_flow_rejects_wrong_state_callback(monkeypatch):
+    # A callback that does carry a code but the wrong state is a real
+    # CSRF signal and must still fail fast.
+    def fake_open(url):
+        redirect_uri = parse_qs(urlparse(url).query)["redirect_uri"][0]
+        threading.Thread(
+            target=lambda: httpx.get(redirect_uri,
+                                     params={"code": "c1", "state": "attacker-state"}),
+            daemon=True,
+        ).start()
+        return True
+
+    monkeypatch.setattr(auth.webbrowser, "open", fake_open)
+    with pytest.raises(RuntimeError, match="State mismatch"):
+        auth.obtain_token_via_browser(BASE, PID, timeout=10)
+
+
+def _fake_browser_pick(monkeypatch, mocker, picked_product_id, token="tok-picked"):
+    """Simulate the full success path: callback with a code, then /mcp/token."""
+    def fake_open(url):
+        q = parse_qs(urlparse(url).query)
+        redirect_uri, state = q["redirect_uri"][0], q["state"][0]
+        threading.Thread(
+            target=lambda: httpx.get(redirect_uri, params={"code": "c1", "state": state}),
+            daemon=True,
+        ).start()
+        return True
+
+    monkeypatch.setattr(auth.webbrowser, "open", fake_open)
+    mocker.patch.object(auth.httpx, "post", return_value=_FakeResp(
+        200, {"token": token, "product_id": picked_product_id,
+              "expires_at": time.time() + 3600},
+    ))
+
+
+def test_browser_flow_returns_picked_product_and_caches_both_keys(monkeypatch, mocker):
+    # Requested with an empty product id (pick-in-browser mode): the flow must
+    # report which product the user picked and cache the token under both the
+    # requested (empty) key and the picked product's key.
+    _fake_browser_pick(monkeypatch, mocker, picked_product_id="picked-prod")
+
+    out = auth.obtain_token_via_browser(BASE, "", timeout=10)
+
+    assert out["token"] == "tok-picked"
+    assert out["product_id"] == "picked-prod"
+    assert auth.load_cached_token(BASE, "") == "tok-picked"
+    assert auth.load_cached_token(BASE, "picked-prod") == "tok-picked"
+
+
+def test_browser_flow_sends_pkce_challenge_matching_its_verifier(monkeypatch, mocker):
+    seen = {}
+
+    def fake_open(url):
+        q = parse_qs(urlparse(url).query)
+        seen["challenge"] = q["code_challenge"][0]
+        redirect_uri, state = q["redirect_uri"][0], q["state"][0]
+        threading.Thread(
+            target=lambda: httpx.get(redirect_uri, params={"code": "c1", "state": state}),
+            daemon=True,
+        ).start()
+        return True
+
+    def fake_post(url, json=None, timeout=None):
+        seen["verifier"] = json["code_verifier"]
+        return _FakeResp(200, {"token": "t", "product_id": PID,
+                               "expires_at": time.time() + 3600})
+
+    monkeypatch.setattr(auth.webbrowser, "open", fake_open)
+    mocker.patch.object(auth.httpx, "post", side_effect=fake_post)
+
+    auth.obtain_token_via_browser(BASE, PID, timeout=10)
+
+    # The server-side transform is the expected value: the client's inline
+    # S256 (mcp_server stays free of breba_app imports) must match it
+    # byte-for-byte or the exchange breaks — divergence fails here, not live.
+    assert seen["challenge"] == make_code_challenge(seen["verifier"])
+
+
+def test_browser_flow_never_caches_picked_token_under_requested_id(monkeypatch, mocker):
+    # The user can change the product in the consent page's picker even when the
+    # flow requested a specific one. The returned token is scoped to the picked
+    # product, so caching it under the requested id would make every later
+    # lookup "for prod-a" silently push to prod-b.
+    _fake_browser_pick(monkeypatch, mocker, picked_product_id="prod-b", token="tok-b")
+
+    out = auth.obtain_token_via_browser(BASE, "prod-a", timeout=10)
+
+    assert out["product_id"] == "prod-b"
+    assert auth.load_cached_token(BASE, "prod-b") == "tok-b"
+    assert auth.load_cached_token(BASE, "prod-a") is None
+    assert auth.load_cached_token(BASE, "") is None  # empty key is pick-in-browser only
+
+
+# --- HTTP client: 401 -> reauth -> retry ------------------------------------
+
+class _FakeResp:
+    def __init__(self, status_code, json_body=None, text=""):
+        self.status_code = status_code
+        self._json = json_body or {}
+        self.text = text
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(self.text, request=None, response=None)
+
+
+def _install_fake_http(mocker, fake_request):
+    """Replace SiteClient's persistent httpx.Client with a request stub."""
+    fake = mocker.Mock()
+    fake.request.side_effect = fake_request
+    return mocker.patch("mcp_server.client.httpx.Client", return_value=fake), fake
+
+
+def test_client_retries_once_on_401(mocker):
+    provider = lambda force=False: "fresh" if force else "stale"  # noqa: E731
+
+    seen_auth = []
+
+    def fake_request(method, url, headers, **kw):
+        seen_auth.append(headers["Authorization"])
+        if headers["Authorization"] == "Bearer stale":
+            return _FakeResp(401, text="unauthorized")
+        return _FakeResp(200, {"files": ["index.html"]})
+
+    _install_fake_http(mocker, fake_request)
+    out = SiteClient(BASE, provider).list_files()
+
+    assert out == {"files": ["index.html"]}
+    assert seen_auth == ["Bearer stale", "Bearer fresh"]
+
+
+def test_client_raises_on_4xx(mocker):
+    _install_fake_http(mocker, lambda *a, **kw: _FakeResp(404, text="Product not found"))
+    with pytest.raises(RuntimeError, match="404"):
+        SiteClient(BASE, lambda force=False: "tok").push([])
+
+
+def test_client_reuses_one_connection_pool(mocker):
+    client_cls, fake = _install_fake_http(mocker, lambda *a, **kw: _FakeResp(200, {}))
+    c = SiteClient(BASE, lambda force=False: "tok")
+    c.list_files()
+    c.list_versions()
+    c.preview()
+    client_cls.assert_called_once_with(base_url=BASE, timeout=60.0)  # one pool
+    assert fake.request.call_count == 3
+
+
+def test_server_caches_one_site_client_per_target(mocker, monkeypatch):
+    site_client = mocker.patch("mcp_server.server.SiteClient",
+                               side_effect=lambda *a: mocker.Mock())
+    first = server._client()
+    assert server._client() is first  # same target -> same client, same pool
+    assert site_client.call_count == 1
+
+    monkeypatch.setattr(server, "_product_override", "prod-9")
+    assert server._client() is not first  # new target -> new client
+    assert site_client.call_count == 2
+
+
+# --- tool encoding/decoding --------------------------------------------------
+
+class _NoAuth:
+    """push_site pre-auths before reading the guard; fakes need the hook only."""
+
+    def ensure_auth(self):
+        pass
+
+
+def test_push_site_base64_encodes_content(mocker):
+    captured = {}
+
+    class FakeClient(_NoAuth):
+        def push(self, files, expected_version=None):
+            captured["files"] = files
+            return {"version": 8, "product_id": PID}
+
+    mocker.patch("mcp_server.server._client", return_value=FakeClient())
+    result = server.push_site([server.FileArg(path="index.html", content="<h1>hi</h1>")])
+
+    assert result == {"version": 8, "product_id": PID}
+    sent = captured["files"][0]
+    assert sent["path"] == "index.html"
+    assert base64.b64decode(sent["content_b64"]).decode() == "<h1>hi</h1>"
+
+
+def _observing_fake_client(pushes: list, fail_with: int | None = None):
+    """FakeClient whose read observes active v6 and whose push records or fails."""
+
+    class FakeClient(_NoAuth):
+        def stat_file(self, path, version=None):
+            return {"content_type": "text/html", "size": 2}
+
+        def read_file(self, path, version=None):
+            return {"path": path, "content_b64": base64.b64encode(b"<p").decode(), "version": 6}
+
+        def push(self, files, expected_version=None):
+            pushes.append(expected_version)
+            if fail_with is not None:
+                raise client_module.SiteApiError(f"POST /mcp/push -> {fail_with}", fail_with)
+            return {"version": 7, "product_id": PID}
+
+    return FakeClient()
+
+
+def test_push_site_uses_the_active_revision_observed_from_a_read(mocker):
+    pushes: list = []
+    mocker.patch("mcp_server.server._client", return_value=_observing_fake_client(pushes))
+
+    server.read_site_file("index.html")
+    server.push_site([server.FileArg(path="index.html", content="<h1>updated</h1>")])
+
+    assert pushes == [6]
+
+
+def test_push_site_forgets_the_guard_when_a_push_fails_after_possibly_saving(mocker):
+    pushes: list = []
+    mocker.patch("mcp_server.server._client",
+                 return_value=_observing_fake_client(pushes, fail_with=500))
+
+    server.read_site_file("index.html")
+    with pytest.raises(client_module.SiteApiError):
+        server.push_site([server.FileArg(path="index.html", content="<h1>fix</h1>")])
+    # The 500 may have saved a revision; the follow-up push must not carry the
+    # now-stale precondition, or it would 409 against the agent's own save.
+    with pytest.raises(client_module.SiteApiError):
+        server.push_site([server.FileArg(path="index.html", content="<h1>fix</h1>")])
+
+    assert pushes == [6, None]
+
+
+def test_push_site_keeps_the_guard_across_a_conflict(mocker):
+    pushes: list = []
+    mocker.patch("mcp_server.server._client",
+                 return_value=_observing_fake_client(pushes, fail_with=409))
+
+    server.read_site_file("index.html")
+    with pytest.raises(client_module.SiteApiError):
+        server.push_site([server.FileArg(path="index.html", content="<h1>fix</h1>")])
+    with pytest.raises(client_module.SiteApiError):
+        server.push_site([server.FileArg(path="index.html", content="<h1>fix</h1>")])
+
+    # A 409 means the guard did its job; only a re-read may refresh it.
+    assert pushes == [6, 6]
+
+
+def test_observed_versions_are_per_mcp_session(mocker):
+    pushes: list = []
+    mocker.patch("mcp_server.server._client",
+                 return_value=_observing_fake_client(pushes))
+
+    session_a = SimpleNamespace(session=object())
+    session_b = SimpleNamespace(session=object())
+    server.read_site_file("index.html", ctx=session_a)
+
+    # B never read the active site; it must not inherit A's guard — and A's
+    # guard must survive B's push (which would otherwise re-arm or clear it).
+    server.push_site([server.FileArg(path="index.html", content="<h1>b</h1>")], ctx=session_b)
+    server.push_site([server.FileArg(path="index.html", content="<h1>a</h1>")], ctx=session_a)
+
+    assert pushes == [None, 6]
+
+
+def test_ctx_is_injected_not_exposed_in_tool_schemas():
+    for name in ("list_site_versions", "list_site_files", "read_site_file",
+                 "download_site_file", "push_site"):
+        tool = server.mcp._tool_manager.get_tool(name)
+        assert tool.context_kwarg == "ctx"
+        assert "ctx" not in tool.parameters.get("properties", {})
+
+
+def test_push_site_reads_the_guard_after_auth_retargets_the_session(mocker):
+    # The consent picker may switch the session to another product during the
+    # push's own first-use auth; the guard must then be the new product's (none
+    # here), not the revision observed on the product just switched away from.
+    pushes: list = []
+    fake = _observing_fake_client(pushes)
+    fake.ensure_auth = lambda: server._adopt_picked_product("other-prod")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+
+    server.read_site_file("index.html")  # observes v6 on the original product
+    server.push_site([server.FileArg(path="index.html", content="<h1>x</h1>")])
+
+    assert pushes == [None]
+
+
+def test_push_site_uses_the_active_revision_observed_from_a_download(mocker, tmp_path):
+    captured = {}
+
+    class FakeClient(_NoAuth):
+        def stat_file(self, path, version=None):
+            return {"content_type": "image/png", "size": 4}
+
+        def read_file(self, path, version=None):
+            return {"path": path, "content_b64": base64.b64encode(b"\x89PNG").decode(), "version": 6}
+
+        def push(self, files, expected_version=None):
+            captured["expected_version"] = expected_version
+            return {"version": 7, "product_id": PID}
+
+    mocker.patch("mcp_server.server._client", return_value=FakeClient())
+
+    server.download_site_file("logo.png", str(tmp_path / "logo.png"))
+    server.push_site([server.FileArg(path="logo.png", local_path=str(tmp_path / "logo.png"))])
+
+    assert captured["expected_version"] == 6
+
+
+def test_push_site_without_an_active_read_keeps_backward_compatible_payload(mocker):
+    captured = {}
+
+    class FakeClient(_NoAuth):
+        def push(self, files, expected_version=None):
+            captured["files"] = files
+            captured["expected_version"] = expected_version
+            return {"version": 7, "product_id": PID}
+
+    mocker.patch("mcp_server.server._client", return_value=FakeClient())
+
+    server.push_site([server.FileArg(path="index.html", content="<h1>updated</h1>")])
+
+    assert captured["files"][0]["path"] == "index.html"
+    # No read happened, so no precondition may reach the wire (SiteClient drops
+    # a None expected_version from the request body).
+    assert captured["expected_version"] is None
+
+
+class _FakeReadClient:
+    """read/stat client stub; records calls so tests can assert what was skipped."""
+
+    def __init__(self, content: bytes, content_type: str = "", size: int | None = None):
+        self._content = content
+        self._stat = {"content_type": content_type,
+                      "size": len(content) if size is None else size}
+        self.read_calls = []
+        self.stat_calls = []
+
+    def stat_file(self, path, version=None):
+        self.stat_calls.append((path, version))
+        return dict(self._stat)
+
+    def read_file(self, path, version=None):
+        self.read_calls.append((path, version))
+        return {"path": path, "content_b64": base64.b64encode(self._content).decode()}
+
+
+def test_read_site_file_decodes_content(mocker):
+    fake = _FakeReadClient(b"body{}", content_type="text/css")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    assert server.read_site_file("styles.css") == {"path": "styles.css", "content": "body{}"}
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00\xffbinary-ish\x80" * 4
+
+
+def _fake_push_client(mocker, captured):
+    class FakeClient(_NoAuth):
+        def push(self, files, expected_version=None):
+            captured["files"] = files
+            return {"version": 9, "product_id": PID}
+
+    mocker.patch("mcp_server.server._client", return_value=FakeClient())
+
+
+def test_push_site_local_path_sends_file_bytes(mocker, tmp_path):
+    asset = tmp_path / "logo.png"
+    asset.write_bytes(PNG_BYTES)
+    captured = {}
+    _fake_push_client(mocker, captured)
+
+    server.push_site([server.FileArg(path="assets/logo.png", local_path=str(asset))])
+
+    sent = captured["files"][0]
+    assert sent["path"] == "assets/logo.png"
+    assert base64.b64decode(sent["content_b64"]) == PNG_BYTES
+    # Bytes from disk may be anything; let the server guess from the extension.
+    assert "content_type" not in sent
+
+
+def test_push_site_sends_text_content_type_for_inline_content(mocker):
+    # Inline content is text by definition. Without an explicit type the server
+    # stamps extensionless files (CNAME, LICENSE) application/octet-stream, and
+    # read_site_file then refuses to read back a file this tool itself pushed.
+    captured = {}
+    _fake_push_client(mocker, captured)
+
+    server.push_site([server.FileArg(path="CNAME", content="breba.example.com"),
+                      server.FileArg(path="index.html", content="<h1>hi</h1>")])
+
+    types = {f["path"]: f["content_type"] for f in captured["files"]}
+    assert types == {"CNAME": "text/plain",       # extension-less: text fallback
+                     "index.html": "text/html"}   # known extension: real type
+
+
+def test_file_arg_requires_exactly_one_source(tmp_path):
+    with pytest.raises(ValueError, match="exactly one"):
+        server.FileArg(path="index.html")
+    with pytest.raises(ValueError, match="exactly one"):
+        server.FileArg(path="index.html", content="<h1/>", local_path=str(tmp_path / "x"))
+
+
+def test_push_site_rejects_missing_local_file(mocker, tmp_path):
+    _fake_push_client(mocker, {})
+    arg = server.FileArg(path="a.png", local_path=str(tmp_path / "nope.png"))
+    with pytest.raises(ValueError, match="not found"):
+        server.push_site([arg])
+
+
+def test_push_site_enforces_size_cap(mocker, tmp_path, monkeypatch):
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "10")
+    _fake_push_client(mocker, {})
+
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"x" * 11)
+    with pytest.raises(ValueError, match="cap is 10 bytes"):
+        server.push_site([server.FileArg(path="big.bin", local_path=str(big))])
+
+    with pytest.raises(ValueError, match="cap is 10 bytes"):
+        server.push_site([server.FileArg(path="a.html", content="y" * 11)])
+
+
+def test_read_site_file_refuses_binary_before_downloading(mocker):
+    fake = _FakeReadClient(PNG_BYTES, content_type="image/png")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    with pytest.raises(ValueError, match="binary file.*download_site_file"):
+        server.read_site_file("logo.png")
+    assert fake.read_calls == []  # refused on the stat, no bytes fetched
+
+
+def test_read_site_file_decode_backstop_for_unknown_content_type(mocker):
+    # A missing/unknown content type passes the stat check; the UTF-8 decode
+    # backstop must still refuse actual binary bytes.
+    fake = _FakeReadClient(PNG_BYTES, content_type="")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    with pytest.raises(ValueError, match="binary file.*download_site_file"):
+        server.read_site_file("mystery.bin")
+    assert len(fake.read_calls) == 1
+
+
+def test_read_site_file_refuses_oversized_before_downloading(mocker, monkeypatch):
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "10")
+    fake = _FakeReadClient(b"x" * 11, content_type="text/html")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    with pytest.raises(ValueError, match="cap is 10 bytes"):
+        server.read_site_file("huge.html")
+    assert fake.read_calls == []
+
+
+def test_read_site_file_cap_backstop_when_manifest_size_is_zero(mocker, monkeypatch):
+    # Version-0 manifests carry placeholder size 0; the post-download check
+    # must still keep an oversized file out of the conversation.
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "10")
+    fake = _FakeReadClient(b"x" * 11, content_type="text/html", size=0)
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    with pytest.raises(ValueError, match="cap is 10 bytes"):
+        server.read_site_file("huge.html")
+
+
+def test_download_site_file_writes_bytes(mocker, tmp_path):
+    fake = _FakeReadClient(PNG_BYTES, content_type="image/png")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    dest = tmp_path / "nested" / "dir" / "logo.png"  # parents created as needed
+    result = server.download_site_file("assets/logo.png", str(dest), version=5)
+
+    assert dest.read_bytes() == PNG_BYTES
+    assert result == {"path": "assets/logo.png", "dest_path": str(dest), "size": len(PNG_BYTES)}
+    assert fake.read_calls == [("assets/logo.png", 5)]
+
+
+def test_download_site_file_enforces_size_cap_before_downloading(mocker, tmp_path, monkeypatch):
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "4")
+    fake = _FakeReadClient(PNG_BYTES, content_type="image/png")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    dest = tmp_path / "logo.png"
+    with pytest.raises(ValueError, match="cap is 4 bytes"):
+        server.download_site_file("logo.png", str(dest))
+    assert not dest.exists()
+    assert fake.read_calls == []  # refused on the manifest size, no download
+
+
+def test_max_file_bytes_defaults_to_20mb(monkeypatch):
+    assert config.max_file_bytes() == 20 * 1024 * 1024
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "1234")
+    assert config.max_file_bytes() == 1234
+    monkeypatch.setenv("BREBA_MCP_MAX_FILE_BYTES", "")  # blank .env line = unset
+    assert config.max_file_bytes() == 20 * 1024 * 1024
+
+
+def test_read_site_file_passes_version(mocker):
+    fake = _FakeReadClient(b"<v5>", content_type="text/html")
+    mocker.patch("mcp_server.server._client", return_value=fake)
+    assert server.read_site_file("index.html", version=5)["content"] == "<v5>"
+    assert fake.read_calls == [("index.html", 5)]
+    assert fake.stat_calls == [("index.html", 5)]
+
+
+def test_client_sends_version_param_only_when_given(mocker):
+    seen_params = []
+
+    def fake_request(method, url, headers, **kw):
+        seen_params.append(kw.get("params"))
+        return _FakeResp(200, {})
+
+    _install_fake_http(mocker, fake_request)
+    c = SiteClient(BASE, lambda force=False: "tok")
+    c.list_files()
+    c.list_files(version=5)
+    c.read_file("index.html")
+    c.read_file("index.html", version=9)
+    c.stat_file("index.html")
+    c.stat_file("index.html", version=9)
+    c.list_versions()
+
+    assert seen_params == [
+        {},
+        {"version": 5},
+        {"path": "index.html"},
+        {"path": "index.html", "version": 9},
+        {"path": "index.html"},
+        {"path": "index.html", "version": 9},
+        None,
+    ]
+
+
+# --- product listing / switching ----------------------------------------------
+
+PRODUCTS_RESPONSE = {
+    "products": [{"id": "prod-1", "name": "Boat Site"}, {"id": "prod-2", "name": "Cafe Site"}],
+    "current": "prod-2",
+}
+
+
+class _FakeProductsClient:
+    def __init__(self, current="prod-2"):
+        self.response = dict(PRODUCTS_RESPONSE, current=current)
+
+    def products(self):
+        return self.response
+
+
+def test_list_products_passes_through(mocker):
+    mocker.patch("mcp_server.server._client", return_value=_FakeProductsClient())
+    assert server.list_products() == dict(PRODUCTS_RESPONSE, current="prod-2")
+
+
+def test_switch_product_with_cached_token_skips_browser(mocker, monkeypatch):
+    # A product that was authorized before switches silently: no browser.
+    auth.save_token(BASE, "prod-2", "tok-2", expires_at=time.time() + 3600)
+    monkeypatch.setattr(server, "obtain_token_via_browser",
+                        lambda *a, **kw: pytest.fail("should not open browser"))
+    mocker.patch("mcp_server.server._client", return_value=_FakeProductsClient())
+
+    result = server.switch_product("prod-2")
+
+    assert result == {"product_id": "prod-2", "name": "Cafe Site"}
+    assert server._active_product_id() == "prod-2"
+
+
+def test_switch_product_without_id_forces_browser_pick(mocker):
+    # Even with a cached token, an empty product_id must reopen the browser so
+    # the user can pick — that IS the switch gesture in pick-in-browser mode.
+    auth.save_token(BASE, "", "tok-old", expires_at=time.time() + 3600)
+    browser = mocker.patch(
+        "mcp_server.server.obtain_token_via_browser",
+        return_value={"token": "tok-1", "product_id": "prod-1",
+                      "expires_at": time.time() + 3600},
+    )
+    mocker.patch("mcp_server.server._client", return_value=_FakeProductsClient(current="prod-1"))
+
+    result = server.switch_product()
+
+    browser.assert_called_once_with(BASE, "")
+    assert result == {"product_id": "prod-1", "name": "Boat Site"}
+    assert server._active_product_id() == "prod-1"
+
+
+def test_switch_product_adopts_product_picked_in_consent_page(mocker, monkeypatch):
+    # No cached token for prod-1 -> browser flow; the user changes the consent
+    # page's picker to prod-2 and approves. The pick is authoritative: the
+    # session must target prod-2, matching the prod-2-scoped token.
+    monkeypatch.setattr(
+        server, "obtain_token_via_browser",
+        lambda base, pid: {"token": "tok-2", "product_id": "prod-2",
+                           "expires_at": time.time() + 3600},
+    )
+    mocker.patch("mcp_server.server._client",
+                 return_value=_FakeProductsClient(current="prod-2"))
+
+    result = server.switch_product("prod-1")
+
+    assert result == {"product_id": "prod-2", "name": "Cafe Site"}
+    assert server._active_product_id() == "prod-2"
+
+
+def test_client_retargets_session_when_user_picks_other_product(mocker, monkeypatch):
+    # A tool call targeting prod-a triggers the browser flow; the user picks
+    # prod-b there. The session override must follow the pick so later calls
+    # use the prod-b token instead of cache-missing on prod-a forever.
+    monkeypatch.setenv("BREBA_PRODUCT_ID", "prod-a")
+    monkeypatch.setattr(
+        auth, "obtain_token_via_browser",
+        lambda base, pid: {"token": "tok-b", "product_id": "prod-b",
+                           "expires_at": time.time() + 3600},
+    )
+    captured = {}
+
+    def fake_site_client(base, provider):
+        captured.setdefault("providers", []).append(provider)
+        return mocker.Mock()
+
+    mocker.patch("mcp_server.server.SiteClient", side_effect=fake_site_client)
+
+    server._client()
+    assert captured["providers"][0](False) == "tok-b"  # browser flow, user picked prod-b
+    assert server._active_product_id() == "prod-b"
+
+
+def test_switch_product_failed_browser_keeps_old_target(mocker, monkeypatch):
+    monkeypatch.setenv("BREBA_PRODUCT_ID", "prod-2")
+    monkeypatch.setattr(
+        server, "obtain_token_via_browser",
+        mocker.Mock(side_effect=RuntimeError("Authorization failed (access_denied)")),
+    )
+    with pytest.raises(RuntimeError, match="access_denied"):
+        server.switch_product("prod-1")
+    assert server._active_product_id() == "prod-2"  # override not committed
+
+
+def test_switch_product_rejected_when_env_token_pins_product(monkeypatch):
+    monkeypatch.setenv("BREBA_MCP_TOKEN", "pinned-token")
+    with pytest.raises(ValueError, match="BREBA_MCP_TOKEN"):
+        server.switch_product("prod-1")
+
+
+# --- listing tools: pass-through and guard arming ------------------------------
+
+def _listing_fake_client(pushes: list):
+    """Fake whose listings report active revision 2 and whose push records the guard."""
+
+    class FakeClient(_NoAuth):
+        def list_versions(self):
+            return {"versions": [0, 1, 2], "active": 2}
+
+        def list_files(self, version=None):
+            v = 2 if version is None else version
+            return {"files": ["index.html"], "version": v}
+
+        def preview(self):
+            return {"preview_url": "http://prod-1.localhost:8088/index.html"}
+
+        def push(self, files, expected_version=None):
+            pushes.append(expected_version)
+            return {"version": 3, "product_id": PID}
+
+    return FakeClient()
+
+
+def test_list_site_versions_passes_through_and_arms_the_guard(mocker):
+    # The active revision is observed by any active-state read, not just
+    # read_site_file: a session that only listed versions must still push guarded.
+    pushes: list = []
+    mocker.patch("mcp_server.server._client", return_value=_listing_fake_client(pushes))
+
+    assert server.list_site_versions() == {"versions": [0, 1, 2], "active": 2}
+    server.push_site([server.FileArg(path="index.html", content="<h1>x</h1>")])
+
+    assert pushes == [2]
+
+
+def test_list_site_files_arms_the_guard_only_for_the_active_listing(mocker):
+    pushes: list = []
+    mocker.patch("mcp_server.server._client", return_value=_listing_fake_client(pushes))
+
+    # A historical listing is reference material, not an edit base: no guard.
+    assert server.list_site_files(version=1) == {"files": ["index.html"], "version": 1}
+    server.push_site([server.FileArg(path="index.html", content="<h1>x</h1>")])
+
+    # An active listing observes the current revision and arms the guard.
+    assert server.list_site_files() == {"files": ["index.html"], "version": 2}
+    server.push_site([server.FileArg(path="index.html", content="<h1>y</h1>")])
+
+    assert pushes == [None, 2]
+
+
+def test_get_preview_url_passes_through(mocker):
+    mocker.patch("mcp_server.server._client", return_value=_listing_fake_client([]))
+    assert server.get_preview_url() == {
+        "preview_url": "http://prod-1.localhost:8088/index.html"}
+
+
+# --- token cache: atomic-write failure path ------------------------------------
+
+def test_failed_cache_write_leaves_no_temp_and_keeps_the_old_cache(mocker):
+    auth.save_token(BASE, PID, "tok-1", expires_at=time.time() + 3600)
+
+    mocker.patch("mcp_server.auth.json.dumps", side_effect=TypeError("boom"))
+    with pytest.raises(TypeError):
+        auth.save_token(BASE, PID, "tok-2", expires_at=time.time() + 3600)
+    mocker.stopall()
+
+    # The failed write's temp file is cleaned up and the old cache survives.
+    path = config.token_file()
+    assert [p.name for p in path.parent.iterdir()] == [path.name]
+    assert auth.load_cached_token(BASE, PID) == "tok-1"
+
+
+# --- __main__: transport selection ----------------------------------------------
+
+def test_main_defaults_to_stdio(mocker, monkeypatch):
+    import mcp_server.__main__ as entry
+
+    run = mocker.patch.object(entry.mcp, "run")
+    monkeypatch.setattr("sys.argv", ["mcp_server"])
+    entry.main()
+    run.assert_called_once_with(transport="stdio")
+
+
+def test_main_http_flag_selects_streamable_http_and_binds(mocker, monkeypatch):
+    import mcp_server.__main__ as entry
+
+    run = mocker.patch.object(entry.mcp, "run")
+    # mcp.settings is module-global state; restore it so later tests (or a
+    # stdio run in the same process) don't inherit this test's bind address.
+    monkeypatch.setattr(entry.mcp, "settings", mocker.Mock(wraps=entry.mcp.settings))
+    monkeypatch.setattr("sys.argv", ["mcp_server", "--http", "--host", "0.0.0.0", "--port", "9009"])
+
+    entry.main()
+
+    run.assert_called_once_with(transport="streamable-http")
+    assert entry.mcp.settings.host == "0.0.0.0"
+    assert entry.mcp.settings.port == 9009


### PR DESCRIPTION
Editing a product today means going through the Chainlit chat UI. That rules out
driving the builder from anything else — in particular, it rules out letting a
coding agent work on a site with the tools it already has.

This adds a headless `/mcp/*` HTTP API over the same operations the UI performs,
and a local MCP server that wraps it, so Claude Code, Codex, Cursor, OpenCode,
agy, Hermes, or a local model can read and edit a Breba site directly.

**22 new files, 2 existing files touched (7 lines).** No dependencies added —
`mcp~=1.11.0` was already in `pyproject.toml`.

## The three commits

| Commit | What |
|---|---|
| `Document a standalone local setup with no cloud accounts` | `STANDALONE_SETUP.md` only — no code |
| `Add an HTTP API for reading and pushing site files` | `breba_app/mcp_api/`, `+4` lines in `main.py` |
| `Add a local MCP server so coding agents can edit a site` | `mcp_server/`, its README |

### Why the setup guide rides along

Running the app currently requires Cloudflare R2, MongoDB Atlas, the
`*.breba.site` preview CDN and Google SSO. Without a local alternative, this PR
can't be exercised at all by anyone who doesn't already have those accounts —
which defeats the point of a feature about running your *own* agent locally.

`STANDALONE_SETUP.md` walks through an all-local stack: MinIO for R2,
containerized MongoDB for Atlas, an optional Caddy proxy for the preview pane,
and password login in place of SSO. It also covers seeding a starter product with
no LLM call, so the app is usable end to end without an OpenAI key.

## API surface

| Endpoint | Purpose |
|---|---|
| `POST /mcp/push` | Write a batch of files as one new version |
| `GET /mcp/versions` | List versions for a product |
| `GET /mcp/files` | List the files in a version |
| `GET /mcp/file` | Read one file |
| `GET /mcp/file/stat` | Metadata only, for cheap change detection |
| `GET /mcp/preview` | The public preview URL |
| `GET /mcp/products` | The products the caller owns |

There is deliberately **no deploy endpoint**. Going live stays a UI-only action.

## Design notes

**Auth reuses the existing session** rather than introducing a second credential
store. An unauthenticated caller is sent to `/mcp/authorize`, signs in with the
normal provider, and picks a product on a consent page; the page hands back a
single-use code exchanged at `/mcp/token` for a bearer token scoped to one
`(user, product)` pair. Codes are short-lived and single-use, and the exchange is
PKCE-bound (S256), so an intercepted code is not enough on its own. Tokens are
stateless HMAC over the existing `CHAINLIT_AUTH_SECRET` — no new server secret,
no schema change, no DB state.

**Push merges, never deletes.** Only the pushed files are written;
`batch_write`'s manifest clone carries unpushed files forward. This matches the
platform-wide append/overwrite-only invariant.

**Optimistic concurrency.** A push carries the revision the agent last read, and
is rejected with `409` if the site moved in the meantime, so an agent can't
silently clobber a chat edit. It's a preflight, not a cross-process transaction;
concurrent writers to a single product remain out of scope.

**Reads and writes are bounded.** Per-file caps on both sides
(`MCP_MAX_FILE_BYTES` server-side, `BREBA_MCP_MAX_FILE_BYTES` client-side, 20 MB
default). Binary and oversized files are refused *before* download; assets move
through `local_path`/`download_site_file` so bytes never enter the model context.

**Performance.** S3 work runs off the event loop, and the preview build skips
uploads that are byte-identical to what the bucket already holds.

**Agents maintain `AGENTS.md`.** The tool descriptions instruct agents to read it
before working and update it after meaningful changes, so MCP agents and the
chat agent keep the same project notes.

## Existing files touched

Kept to the minimum:

- `breba_app/main.py` — 2 imports, 2 `include_router` calls.
- `breba_app/sample.env` — 2 comment lines documenting the optional
  `MCP_MAX_FILE_BYTES`.

Nothing else is modified, moved, or renamed.

## Testing

154 new tests, all passing. They cover token signing/expiry/tampering, the
consent and PKCE flows, path sanitization, the size caps, the `409` conflict
path, the binary/text split, and the MCP tool layer.

One gap worth naming: the `/mcp/*` handlers are tested against a mocked store
layer. The manifest-merge semantics they depend on are covered by the existing
`tests/test_versioned_r2.py` fake, and the full path was verified manually
end to end against MinIO — but there's no automated test that drives
`/mcp/push` through real storage. It's left out to avoid adding a `moto`
dependency and the CI surface that comes with it.

The repo's pre-existing test failures (missing `.secrets`, integration tests
needing live infra) are unchanged by this branch — same set on `main`.

## Out of scope

- No deploy/go-live endpoint.
- No token revocation endpoint — tokens are stateless and expire after 30 days;
  rotating `CHAINLIT_AUTH_SECRET` invalidates all of them.
- Single-process assumptions: the consumed-code registry and the live-session
  overlay are per-process, matching how the app is deployed today.
